### PR TITLE
Replace raw dp with SizeConstants

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/components/AppCard.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/components/AppCard.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import coil3.compose.AsyncImage
 import com.d4rk.android.apps.apptoolkit.app.apps.domain.model.AppInfo
@@ -60,7 +59,7 @@ fun AppCard(appInfo : AppInfo , modifier : Modifier) {
             LargeVerticalSpacer()
             AsyncImage(
                 model = appInfo.iconUrl , contentDescription = appInfo.name , modifier = Modifier
-                        .size(size = 72.dp)
+                        .size(size = SizeConstants.ExtraExtraLargeSize + SizeConstants.LargeSize + SizeConstants.SmallSize)
                         .clip(shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)) , contentScale = ContentScale.Fit
             )
             LargeVerticalSpacer()

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/components/screens/loading/ShimmerPlaceholderAppCard.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/components/screens/loading/ShimmerPlaceholderAppCard.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.shimmerEffect
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -32,7 +31,7 @@ fun ShimmerPlaceholderAppCard(modifier : Modifier = Modifier , aspectRatio : Flo
             LargeVerticalSpacer()
             Box(
                 modifier = Modifier
-                        .size(72.dp)
+                        .size(SizeConstants.ExtraExtraLargeSize + SizeConstants.LargeSize + SizeConstants.SmallSize)
                         .clip(shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize))
                         .shimmerEffect()
             )

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/onboarding/ui/tabs/CustomFunOnboardingPageTab.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/onboarding/ui/tabs/CustomFunOnboardingPageTab.kt
@@ -3,9 +3,7 @@ package com.d4rk.android.apps.apptoolkit.app.onboarding.ui.tabs
 import android.content.Intent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
@@ -13,8 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.apps.apptoolkit.app.main.ui.MainActivity
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.MediumVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 @Composable
@@ -28,7 +26,7 @@ fun CustomFunOnboardingPageTab() {
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text("This is a fully custom tab!")
-        Spacer(Modifier.height(12.dp))
+        MediumVerticalSpacer()
         Button(onClick = {
             context.startActivity(Intent(context, MainActivity::class.java))
         }) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.events.AdsSettingsEvents
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.model.AdsSettingsData
@@ -90,7 +89,7 @@ fun AdSettingsScreenContent(viewModel : AdsSettingsViewModel , activity : Activi
                 InfoMessageSection(
                     modifier = Modifier
                             .fillMaxWidth()
-                            .padding(all = 24.dp) , message = stringResource(id = R.string.summary_ads) , learnMoreText = stringResource(id = R.string.learn_more) , learnMoreUrl = AppLinks.ADS_HELP_CENTER
+                            .padding(all = SizeConstants.MediumSize * 2) , message = stringResource(id = R.string.summary_ads) , learnMoreText = stringResource(id = R.string.learn_more) , learnMoreUrl = AppLinks.ADS_HELP_CENTER
                 )
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsList.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.ui.components.ConsentSectionHeader
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.ui.components.ConsentToggleCard
@@ -163,7 +162,7 @@ fun UsageAndDiagnosticsList(paddingValues: PaddingValues, configProvider: BuildI
             InfoMessageSection(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(all = 24.dp),
+                    .padding(all = SizeConstants.MediumSize * 2),
                 message = stringResource(id = R.string.summary_usage_and_diagnostics),
                 learnMoreText = stringResource(id = R.string.learn_more),
                 learnMoreUrl = AppLinks.PRIVACY_POLICY

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/components/ConsentToggleCard.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/components/ConsentToggleCard.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -57,7 +56,7 @@ fun ConsentToggleCard(
                     imageVector = icon,
                     contentDescription = stringResource(R.string.icon_desc_consent_category),
                     tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(24.dp)
+                    modifier = Modifier.size(SizeConstants.LargeIncreasedSize + SizeConstants.ExtraSmallSize)
                 )
                 LargeHorizontalSpacer()
                 Column(modifier = Modifier.weight(weight = 1f)) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.help.domain.events.HelpEvents
 import com.d4rk.android.libs.apptoolkit.app.help.domain.model.ui.HelpScreenConfig
@@ -105,7 +104,7 @@ fun HelpScreenContent(helpData : UiHelpScreen , paddingValues : PaddingValues , 
                 view.playSoundEffect(SoundEffectConstants.CLICK)
                 IntentsHelper.sendEmailToDeveloper(context = activity , applicationNameRes = R.string.app_name)
             })
-            Spacer(modifier = Modifier.height(height = 96.dp))
+            Spacer(modifier = Modifier.height(height = SizeConstants.ExtraExtraLargeSize * 2))
         }
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/components/QuestionCard.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/components/QuestionCard.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -58,7 +57,7 @@ fun QuestionCard(title : String , summary : String , isExpanded : Boolean , onTo
                 )
 
                 Icon(
-                    imageVector = if (isExpanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore , contentDescription = null , tint = MaterialTheme.colorScheme.primary , modifier = Modifier.size(size = 24.dp)
+                    imageVector = if (isExpanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore , contentDescription = null , tint = MaterialTheme.colorScheme.primary , modifier = Modifier.size(size = SizeConstants.LargeIncreasedSize + SizeConstants.ExtraSmallSize)
                 )
             }
             if (isExpanded) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/AmoledModeToggle.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/AmoledModeToggle.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -31,12 +30,12 @@ fun AmoledModeToggle(
     isAmoledMode : Boolean , onCheckedChange : (Boolean) -> Unit
 ) {
     Surface(
-        modifier = Modifier.fillMaxWidth() , shape = RoundedCornerShape(16.dp) , color = MaterialTheme.colorScheme.surfaceContainerHighest , tonalElevation = 3.dp , shadowElevation = 3.dp
+        modifier = Modifier.fillMaxWidth() , shape = RoundedCornerShape(SizeConstants.LargeSize) , color = MaterialTheme.colorScheme.surfaceContainerHighest , tonalElevation = SizeConstants.ExtraSmallSize , shadowElevation = SizeConstants.ExtraSmallSize
     ) {
         Row(modifier = Modifier
                 .fillMaxWidth()
                 .clickable { onCheckedChange(! isAmoledMode) }
-                .padding(horizontal = 24.dp , vertical = SizeConstants.LargeIncreasedSize) , verticalAlignment = Alignment.CenterVertically , horizontalArrangement = Arrangement.SpaceBetween) {
+                .padding(horizontal = SizeConstants.MediumSize * 2 , vertical = SizeConstants.LargeIncreasedSize) , verticalAlignment = Alignment.CenterVertically , horizontalArrangement = Arrangement.SpaceBetween) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = stringResource(id = R.string.amoled_mode) , style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold) , color = MaterialTheme.colorScheme.onSurface

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/OnboardingBottomNavigation.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/OnboardingBottomNavigation.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -51,7 +50,7 @@ fun OnboardingBottomNavigation(
         Row(
             modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp , vertical = 8.dp) , verticalAlignment = Alignment.CenterVertically , horizontalArrangement = Arrangement.SpaceBetween
+                    .padding(horizontal = SizeConstants.LargeSize , vertical = SizeConstants.SmallSize) , verticalAlignment = Alignment.CenterVertically , horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Box(modifier = Modifier.weight(1f)) {
                 this@Row.AnimatedVisibility(visible = pagerState.currentPage > 0 , modifier = Modifier.fillMaxWidth() , enter = slideInHorizontally(initialOffsetX = { - it } , animationSpec = spring(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/PageIndicatorDots.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/PageIndicatorDots.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -28,7 +27,7 @@ fun PageIndicatorDots(
 ) {
     Row(
         modifier = modifier.animateContentSize(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+        horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize, Alignment.CenterHorizontally),
         verticalAlignment = Alignment.CenterVertically
     ) {
         repeat(pageCount) { index ->
@@ -43,7 +42,7 @@ fun PageIndicatorDots(
             )
             val color = if (isSelected) MaterialTheme.colorScheme.primary
             else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-            val baseDotSize = 8.dp
+            val baseDotSize = SizeConstants.SmallSize
 
             Box(
                 modifier = Modifier

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/ThemeChoiceCard.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/ThemeChoiceCard.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.oboarding.domain.data.model.OnboardingThemeChoice
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
@@ -57,18 +56,18 @@ fun ThemeChoiceCard(
         BorderStroke(SizeConstants.ExtraTinySize , MaterialTheme.colorScheme.primary)
     }
     else {
-        BorderStroke(1.dp , MaterialTheme.colorScheme.outlineVariant)
+        BorderStroke(SizeConstants.ExtraTinySize / 2 , MaterialTheme.colorScheme.outlineVariant)
     }
 
     Card(
         modifier = Modifier
                 .fillMaxWidth()
                 .bounceClick()
-                .clickable(onClick = onClick) , shape = RoundedCornerShape(16.dp) , colors = cardColors , elevation = CardDefaults.cardElevation(defaultElevation = if (isSelected) 4.dp else 1.dp) , border = border
+                .clickable(onClick = onClick) , shape = RoundedCornerShape(SizeConstants.LargeSize) , colors = cardColors , elevation = CardDefaults.cardElevation(defaultElevation = if (isSelected) SizeConstants.ExtraSmallSize else SizeConstants.ExtraTinySize / 2) , border = border
     ) {
         Row(
             modifier = Modifier
-                    .padding(horizontal = 24.dp , vertical = SizeConstants.LargeIncreasedSize)
+                    .padding(horizontal = SizeConstants.MediumSize * 2 , vertical = SizeConstants.LargeIncreasedSize)
                     .fillMaxWidth() , verticalAlignment = Alignment.CenterVertically , horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -97,7 +96,7 @@ fun ThemeChoiceCard(
                             .background(MaterialTheme.colorScheme.primary) , contentAlignment = Alignment.Center
                 ) {
                     Icon(
-                        imageVector = Icons.Filled.Tonality , contentDescription = stringResource(R.string.selected) , tint = MaterialTheme.colorScheme.onPrimary , modifier = Modifier.size(18.dp)
+                        imageVector = Icons.Filled.Tonality , contentDescription = stringResource(R.string.selected) , tint = MaterialTheme.colorScheme.onPrimary , modifier = Modifier.size(SizeConstants.SmallSize * 2 + SizeConstants.ExtraTinySize)
                     )
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
@@ -54,7 +54,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.net.toUri
@@ -102,7 +101,7 @@ fun CrashlyticsOnboardingPageTab(configProvider: BuildInfoProvider = koinInject(
             Icon(
                 imageVector = Icons.Outlined.Analytics,
                 contentDescription = null,
-                modifier = Modifier.size(size = 64.dp),
+                modifier = Modifier.size(size = SizeConstants.ExtraExtraLargeSize + SizeConstants.LargeSize),
                 tint = MaterialTheme.colorScheme.primary
             )
 
@@ -174,7 +173,7 @@ fun UsageAndDiagnosticsToggleCard(
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
         ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 3.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = SizeConstants.ExtraSmallSize - SizeConstants.ExtraTinySize / 2)
     ) {
         Row(
             modifier = Modifier
@@ -230,7 +229,7 @@ fun UsageAndDiagnosticsToggleCard(
 fun LearnMoreSection(context: Context) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         HorizontalDivider(
-            modifier = Modifier.padding(vertical = SizeConstants.LargeSize), thickness = 0.5.dp
+            modifier = Modifier.padding(vertical = SizeConstants.LargeSize), thickness = SizeConstants.ExtraTinySize / 4
         )
         Text(
             text = stringResource(R.string.onboarding_crashlytics_privacy_info),
@@ -435,7 +434,7 @@ fun ConsentToggleItem(
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
         ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = SizeConstants.ExtraTinySize / 2)
     ) {
         Row(
             modifier = Modifier

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/FinalOnboardingPageTab.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/FinalOnboardingPageTab.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.oboarding.utils.helpers.FinalOnboardingKonfettiState
@@ -81,10 +80,10 @@ fun FinalOnboardingPageTab() {
         Column(
             modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 24.dp , vertical = SizeConstants.ExtraLargeIncreasedSize) , horizontalAlignment = Alignment.CenterHorizontally , verticalArrangement = Arrangement.Center
+                    .padding(horizontal = SizeConstants.MediumSize * 2 , vertical = SizeConstants.ExtraLargeIncreasedSize) , horizontalAlignment = Alignment.CenterHorizontally , verticalArrangement = Arrangement.Center
         ) {
             Icon(imageVector = Icons.Filled.CheckCircle , contentDescription = stringResource(id = R.string.onboarding_complete_icon_desc) , modifier = Modifier
-                    .size(size = 80.dp)
+                    .size(size = SizeConstants.ExtraExtraLargeSize + SizeConstants.ExtraLargeIncreasedSize)
                     .graphicsLayer {
                         scaleX = iconSettleScale
                         scaleY = iconSettleScale

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.permissions.domain.actions.PermissionsEvent
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsConfig
@@ -72,7 +71,7 @@ fun PermissionsContent(paddingValues : PaddingValues , settingsConfig : Settings
                         ExtraTinyVerticalSpacer()
                     }
                 }
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(SizeConstants.MediumSize * 2))
             }
         }
     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -127,7 +127,7 @@ fun SettingsDetailPlaceholder(paddingValues : PaddingValues) {
                         .fillMaxSize()
                         .wrapContentHeight() , shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)
             ) {
-                Column(modifier = Modifier.padding(all = 24.dp) , horizontalAlignment = Alignment.CenterHorizontally , verticalArrangement = Arrangement.Center) {
+                Column(modifier = Modifier.padding(all = SizeConstants.MediumSize * 2) , horizontalAlignment = Alignment.CenterHorizontally , verticalArrangement = Arrangement.Center) {
                     AsyncImage(
                         model = R.drawable.il_settings , contentDescription = null , modifier = Modifier
                                 .size(size = 258.dp)
@@ -139,7 +139,7 @@ fun SettingsDetailPlaceholder(paddingValues : PaddingValues) {
                     Text(text = stringResource(id = R.string.settings_placeholder_description) , style = MaterialTheme.typography.bodyMedium , textAlign = TextAlign.Center)
                 }
                 OutlinedButton(modifier = Modifier
-                        .padding(all = 24.dp)
+                        .padding(all = SizeConstants.MediumSize * 2)
                         .align(alignment = Alignment.Start)
                         .bounceClick() , onClick = { IntentsHelper.openActivity(context = context , activityClass = HelpActivity::class.java) }) {
                     Icon(imageVector = Icons.AutoMirrored.Outlined.ContactSupport , contentDescription = null)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color.Companion.Gray
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.startup.domain.model.StartupUiData
@@ -66,7 +65,7 @@ fun StartupScreenContent(paddingValues : PaddingValues) {
         modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues = paddingValues)
-                .padding(all = 24.dp)
+                .padding(all = SizeConstants.MediumSize * 2)
                 .safeDrawingPadding()
     ) {
         LazyColumn(modifier = Modifier.fillMaxSize()) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/theme/ThemeSettingsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/theme/ThemeSettingsList.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.sections.InfoMessageSection
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
@@ -72,7 +71,7 @@ fun ThemeSettingsList(paddingValues : PaddingValues) {
                 Column(
                     modifier = Modifier
                             .fillMaxWidth()
-                            .padding(all = 24.dp)
+                            .padding(all = SizeConstants.MediumSize * 2)
                 ) {
                     themeOptions.forEach { option : ThemeSettingOption ->
                         Row(modifier = Modifier.fillMaxWidth() , verticalAlignment = Alignment.CenterVertically) {
@@ -93,7 +92,7 @@ fun ThemeSettingsList(paddingValues : PaddingValues) {
                 InfoMessageSection(
                     modifier = Modifier
                             .fillMaxWidth()
-                            .padding(all = 24.dp) , message = stringResource(id = R.string.summary_dark_theme)
+                            .padding(all = SizeConstants.MediumSize * 2) , message = stringResource(id = R.string.summary_dark_theme)
                 )
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/carousel/CustomCarousel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/carousel/CustomCarousel.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.hapticPagerSwipe
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
 import kotlin.math.absoluteValue
@@ -41,10 +40,10 @@ fun <T> CustomCarousel(
         DotsIndicator(
             modifier = Modifier
                     .align(alignment = Alignment.CenterHorizontally)
-                    .padding(bottom = 8.dp) ,
+                    .padding(bottom = SizeConstants.SmallSize) ,
             totalDots = items.size ,
             selectedIndex = pagerState.currentPage ,
-            dotSize = 6.dp ,
+            dotSize = SizeConstants.MediumSize / 2 ,
         )
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
@@ -54,7 +53,7 @@ fun NoDataScreen(text : Int = R.string.try_again , icon : ImageVector = Icons.De
         Column(horizontalAlignment = Alignment.CenterHorizontally , verticalArrangement = Arrangement.Center) {
             Icon(
                 imageVector = icon , contentDescription = null , modifier = Modifier
-                        .size(size = 58.dp)
+                        .size(size = SizeConstants.ExtraExtraLargeSize + SizeConstants.SmallSize + SizeConstants.ExtraTinySize)
                         .padding(bottom = SizeConstants.LargeSize) , tint = MaterialTheme.colorScheme.primary
             )
             Text(text = stringResource(id = text) , style = MaterialTheme.typography.displaySmall.copy(textAlign = TextAlign.Center) , color = MaterialTheme.colorScheme.onBackground)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NonLazyGrid.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NonLazyGrid.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun NonLazyGrid(
@@ -25,7 +24,7 @@ fun NonLazyGrid(
                         Box(
                             modifier = Modifier
                                     .weight(weight = 1f)
-                                    .padding(all = 8.dp)
+                                    .padding(all = SizeConstants.SmallSize)
                                     .aspectRatio(ratio = 1f)
                         ) {
                             content(index)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/preferences/SwitchCardItem.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/preferences/SwitchCardItem.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.switches.CustomSwitch
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
@@ -44,7 +43,7 @@ fun SwitchCardItem(title : String , switchState : State<Boolean> , onSwitchToggl
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer) ,
         modifier = Modifier
                 .fillMaxWidth()
-                .padding(all = 24.dp)
+                .padding(all = SizeConstants.MediumSize * 2)
                 .clip(shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize))
                 .clickable {
                     view.playSoundEffect(SoundEffectConstants.CLICK)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/preferences/SwitchPreferenceItemWithDivider.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/preferences/SwitchPreferenceItemWithDivider.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraSmallHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.components.switches.CustomSwitch
@@ -82,8 +81,8 @@ fun SwitchPreferenceItemWithDivider(icon : ImageVector? = null , title : String 
             ExtraSmallHorizontalSpacer()
             VerticalDivider(
                 modifier = Modifier
-                        .height(height = 36.dp)
-                        .align(alignment = Alignment.CenterVertically) , color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f) , thickness = 1.dp
+                        .height(height = SizeConstants.MediumSize * 3)
+                        .align(alignment = Alignment.CenterVertically) , color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f) , thickness = SizeConstants.ExtraTinySize / 2
             )
             CustomSwitch(
                 checked = checked,


### PR DESCRIPTION
## Summary
- refactor composable screens to use `SizeConstants` and premade spacers
- remove unused `dp` imports

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff0e86fa0832d9c8724161798fd3d