### PR TITLE
Add onboarding consent view model

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
@@ -20,6 +20,10 @@ import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentManagerHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.google.android.gms.ads.MobileAds
+import com.google.android.ump.ConsentForm
+import com.google.android.ump.ConsentInformation
+import com.google.android.ump.ConsentRequestParameters
+import com.google.android.ump.UserMessagingPlatform
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -47,6 +51,7 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         viewModel.onEvent(event = MainEvent.CheckForUpdates)
+        checkUserConsent()
     }
 
     private fun initializeDependencies() {
@@ -86,5 +91,21 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    private fun checkUserConsent() {
+        val consentInfo: ConsentInformation = UserMessagingPlatform.getConsentInformation(this)
+        val params = ConsentRequestParameters.Builder()
+            .setTagForUnderAgeOfConsent(false)
+            .build()
+        consentInfo.requestConsentInfoUpdate(this, params, {
+            if (consentInfo.isConsentFormAvailable &&
+                consentInfo.consentStatus == ConsentInformation.ConsentStatus.REQUIRED
+            ) {
+                UserMessagingPlatform.loadConsentForm(this, { form: ConsentForm ->
+                    form.show(this) {}
+                }, {})
+            }
+        }, {})
     }
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -9,6 +9,7 @@ import com.d4rk.android.libs.apptoolkit.app.help.domain.usecases.RequestReviewFl
 import com.d4rk.android.libs.apptoolkit.app.help.ui.HelpViewModel
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.StartupViewModel
 import com.d4rk.android.libs.apptoolkit.app.startup.utils.interfaces.providers.StartupProvider
+import com.d4rk.android.libs.apptoolkit.app.oboarding.ui.OnboardingViewModel
 import com.d4rk.android.libs.apptoolkit.app.support.domain.usecases.QueryProductDetailsUseCase
 import com.d4rk.android.libs.apptoolkit.app.support.ui.SupportViewModel
 import org.koin.core.module.Module
@@ -20,6 +21,10 @@ val appToolkitModule : Module = module {
 
     viewModel {
         StartupViewModel(loadConsentInfoUseCase = get() , dispatcherProvider = get())
+    }
+
+    viewModel {
+        OnboardingViewModel(loadConsentInfoUseCase = get() , dispatcherProvider = get())
     }
 
     single<QueryProductDetailsUseCase> { QueryProductDetailsUseCase() }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/domain/actions/OnboardingAction.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/domain/actions/OnboardingAction.kt
@@ -1,0 +1,7 @@
+package com.d4rk.android.libs.apptoolkit.app.oboarding.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
+
+sealed class OnboardingAction : ActionEvent {
+    data object NavigateToNextScreen : OnboardingAction()
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/domain/actions/OnboardingEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/domain/actions/OnboardingEvent.kt
@@ -1,0 +1,9 @@
+package com.d4rk.android.libs.apptoolkit.app.oboarding.domain.actions
+
+import android.app.Activity
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
+
+sealed class OnboardingEvent : UiEvent {
+    data class OpenConsentForm(val activity: Activity) : OnboardingEvent()
+    data object LoadConsentInfo : OnboardingEvent()
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/domain/model/OnboardingUiData.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/domain/model/OnboardingUiData.kt
@@ -1,0 +1,12 @@
+package com.d4rk.android.libs.apptoolkit.app.oboarding.domain.model
+
+import com.google.android.ump.ConsentInformation
+
+/**
+ * Holds UI related data for the onboarding flow.
+ */
+data class OnboardingUiData(
+    val consentRequired: Boolean = false,
+    val consentFormLoaded: Boolean = false,
+    val consentInformation: ConsentInformation? = null
+)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingActivity.kt
@@ -8,14 +8,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupEvent
-import com.d4rk.android.libs.apptoolkit.app.startup.ui.StartupViewModel
+import com.d4rk.android.libs.apptoolkit.app.oboarding.domain.actions.OnboardingEvent
+import com.d4rk.android.libs.apptoolkit.app.oboarding.ui.OnboardingViewModel
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class OnboardingActivity : ComponentActivity() {
 
-    private val viewModel : StartupViewModel by viewModel()
+    private val viewModel : OnboardingViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,6 +34,6 @@ class OnboardingActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
-        viewModel.onEvent(event = StartupEvent.OpenConsentForm(activity = this@OnboardingActivity))
+        viewModel.onEvent(event = OnboardingEvent.OpenConsentForm(activity = this@OnboardingActivity))
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingViewModel.kt
@@ -1,0 +1,93 @@
+package com.d4rk.android.libs.apptoolkit.app.oboarding.ui
+
+import android.app.Activity
+import androidx.lifecycle.viewModelScope
+import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.app.ads.domain.usecases.LoadConsentInfoUseCase
+import com.d4rk.android.libs.apptoolkit.app.oboarding.domain.actions.OnboardingAction
+import com.d4rk.android.libs.apptoolkit.app.oboarding.domain.actions.OnboardingEvent
+import com.d4rk.android.libs.apptoolkit.app.oboarding.domain.model.OnboardingUiData
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.applyResult
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.successData
+import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import com.google.android.ump.ConsentForm
+import com.google.android.ump.ConsentInformation
+import com.google.android.ump.ConsentRequestParameters
+import com.google.android.ump.UserMessagingPlatform
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+
+class OnboardingViewModel(
+    private val loadConsentInfoUseCase: LoadConsentInfoUseCase,
+    private val dispatcherProvider: DispatcherProvider
+) : ScreenViewModel<OnboardingUiData, OnboardingEvent, OnboardingAction>(
+    initialState = UiStateScreen(data = OnboardingUiData())
+) {
+
+    init {
+        onEvent(event = OnboardingEvent.LoadConsentInfo)
+    }
+
+    override fun onEvent(event: OnboardingEvent) {
+        when (event) {
+            is OnboardingEvent.OpenConsentForm -> openConsentForm(activity = event.activity)
+            is OnboardingEvent.LoadConsentInfo -> loadConsentInfo()
+        }
+    }
+
+    private fun loadConsentInfo() {
+        launch(context = dispatcherProvider.io) {
+            loadConsentInfoUseCase().stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.Lazily,
+                initialValue = DataState.Loading()
+            ).collect { result: DataState<ConsentInformation, Errors> ->
+                screenState.applyResult(
+                    result = result,
+                    errorMessage = UiTextHelper.StringResource(R.string.error_loading_consent_info)
+                ) { consentInfo: ConsentInformation, current: OnboardingUiData ->
+                    current.copy(
+                        consentRequired = consentInfo.isConsentFormAvailable &&
+                            consentInfo.consentStatus == ConsentInformation.ConsentStatus.REQUIRED,
+                        consentInformation = consentInfo
+                    )
+                }
+            }
+        }
+    }
+
+    private fun openConsentForm(activity: Activity) {
+        screenData?.consentInformation?.let { consentInfo: ConsentInformation ->
+            launch(context = dispatcherProvider.io) {
+                val params = ConsentRequestParameters.Builder()
+                    .setTagForUnderAgeOfConsent(false)
+                    .build()
+
+                consentInfo.requestConsentInfoUpdate(activity, params, {
+                    UserMessagingPlatform.loadConsentForm(activity, { consentForm: ConsentForm ->
+                        if (consentInfo.consentStatus == ConsentInformation.ConsentStatus.REQUIRED ||
+                            consentInfo.consentStatus == ConsentInformation.ConsentStatus.OBTAINED
+                        ) {
+                            consentForm.show(activity) {
+                                onConsentFormLoaded()
+                            }
+                        }
+                    }, {})
+                }, {})
+            }
+        } ?: onConsentFormLoaded()
+    }
+
+    private fun onConsentFormLoaded() {
+        launch {
+            screenState.successData {
+                copy(consentFormLoaded = true)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add OnboardingViewModel using LoadConsentInfoUseCase
- wire new view model into OnboardingActivity and DI
- check for consent on MainActivity resume

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400981177c832db3d7674170928171