### PR TITLE
Add component catalog with search and caching

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,6 +70,11 @@
                 android:resource="@xml/shortcuts" />
         </activity>
 
+        <activity
+            android:name=".app.catalog.ComponentsCatalogActivity"
+            android:exported="false"
+            android:theme="@style/AppTheme" />
+
         <service
             android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
             android:enabled="false"

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/AppsListScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/AppsListScreen.kt
@@ -1,6 +1,17 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.ui
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Sort
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -17,6 +28,7 @@ import org.koin.compose.viewmodel.koinViewModel
 fun AppsListScreen(paddingValues : PaddingValues) {
     val viewModel : AppsListViewModel = koinViewModel()
     val screenState : UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsState()
+    val query by viewModel.searchQuery.collectAsState()
     // Content does not trigger in-app review directly; handled in MainActivity
 
     ScreenStateHandler(screenState = screenState , onLoading = {
@@ -26,6 +38,21 @@ fun AppsListScreen(paddingValues : PaddingValues) {
             viewModel.onEvent(HomeEvent.FetchApps)
         })
     } , onSuccess = { uiHomeScreen ->
-        AppsList(uiHomeScreen = uiHomeScreen , paddingValues = paddingValues)
+        Column {
+            OutlinedTextField(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = SizeConstants.MediumSize, vertical = SizeConstants.SmallSize),
+                value = query,
+                onValueChange = { viewModel.updateSearchQuery(it) },
+                label = { Text(text = "Search") }
+            )
+            Row(modifier = Modifier.padding(horizontal = SizeConstants.MediumSize)) {
+                IconButton(onClick = { viewModel.toggleSortOrder() }) {
+                    Icon(imageVector = Icons.Outlined.Sort, contentDescription = "Sort")
+                }
+            }
+            AppsList(uiHomeScreen = uiHomeScreen , paddingValues = paddingValues)
+        }
     })
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/AppsListViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/AppsListViewModel.kt
@@ -5,6 +5,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.domain.actions.HomeEvent
 import com.d4rk.android.apps.apptoolkit.app.apps.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.domain.model.ui.UiHomeScreen
 import com.d4rk.android.apps.apptoolkit.app.apps.domain.usecases.FetchDeveloperAppsUseCase
+import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
@@ -12,10 +13,30 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 
-class AppsListViewModel(private val fetchDeveloperAppsUseCase : FetchDeveloperAppsUseCase , private val dispatcherProvider : DispatcherProvider) : ScreenViewModel<UiHomeScreen , HomeEvent , HomeAction>(initialState = UiStateScreen(screenState = ScreenState.IsLoading() , data = UiHomeScreen())) {
+class AppsListViewModel(
+    private val fetchDeveloperAppsUseCase: FetchDeveloperAppsUseCase,
+    private val dispatcherProvider: DispatcherProvider,
+    private val dataStore: DataStore
+) : ScreenViewModel<UiHomeScreen, HomeEvent, HomeAction>(
+    initialState = UiStateScreen(screenState = ScreenState.IsLoading(), data = UiHomeScreen())
+) {
+
+    private var allApps: List<AppInfo> = emptyList()
+
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery = _searchQuery.asStateFlow()
+
+    private val _sortAscending = MutableStateFlow(true)
+    val sortAscending = _sortAscending.asStateFlow()
 
     init {
         onEvent(event = HomeEvent.FetchApps)
@@ -27,25 +48,63 @@ class AppsListViewModel(private val fetchDeveloperAppsUseCase : FetchDeveloperAp
         }
     }
 
+    fun updateSearchQuery(query: String) {
+        _searchQuery.value = query
+        applyFilters()
+    }
+
+    fun toggleSortOrder() {
+        _sortAscending.value = !_sortAscending.value
+        applyFilters()
+    }
+
+    private fun applyFilters() {
+        val filtered = allApps.filter { it.name.contains(searchQuery.value, ignoreCase = true) }
+        val sorted = if (sortAscending.value) {
+            filtered.sortedBy { it.name.lowercase() }
+        } else {
+            filtered.sortedByDescending { it.name.lowercase() }
+        }
+        screenState.updateData { currentData ->
+            currentData.copy(apps = sorted)
+        }
+    }
+
     private fun fetchDeveloperApps() {
         launch(context = dispatcherProvider.io) {
-            fetchDeveloperAppsUseCase().flowOn(dispatcherProvider.default).collect { result : DataState<List<AppInfo> , RootError> ->
+            fetchDeveloperAppsUseCase().flowOn(dispatcherProvider.default).collect { result: DataState<List<AppInfo>, RootError> ->
                 when (result) {
                     is DataState.Success -> {
                         val apps = result.data
+                        allApps = apps
+                        dataStore.saveCachedApps(Json.encodeToString(apps))
                         if (apps.isEmpty()) {
                             screenState.update { currentState ->
-                                currentState.copy(screenState = ScreenState.NoData() , data = currentState.data?.copy(apps = emptyList()))
+                                currentState.copy(screenState = ScreenState.NoData(), data = currentState.data?.copy(apps = emptyList()))
                             }
-                        }
-                        else {
-                            screenState.updateData(ScreenState.Success()) { currentData ->
-                                currentData.copy(apps = apps)
+                        } else {
+                            applyFilters()
+                            screenState.update { currentState ->
+                                currentState.copy(screenState = ScreenState.Success())
                             }
                         }
                     }
 
-                    else -> {}
+                    else -> {
+                        val cached = dataStore.cachedApps.first()
+                        if (cached != null) {
+                            runCatching {
+                                Json.decodeFromString<List<AppInfo>>(cached)
+                            }.onSuccess { cachedApps ->
+                                if (cachedApps.isNotEmpty()) {
+                                    allApps = cachedApps
+                                    screenState.updateData(ScreenState.Success()) { currentData ->
+                                        currentData.copy(apps = cachedApps)
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/catalog/ComponentsCatalogActivity.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/catalog/ComponentsCatalogActivity.kt
@@ -1,0 +1,23 @@
+package com.d4rk.android.apps.apptoolkit.app.catalog
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
+import com.d4rk.android.apps.apptoolkit.app.main.ui.theme.AppTheme
+
+class ComponentsCatalogActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AppTheme {
+                Surface(modifier = Modifier) {
+                    ComponentsCatalogScreen(paddingValues = PaddingValues())
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/catalog/ComponentsCatalogScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/catalog/ComponentsCatalogScreen.kt
@@ -1,0 +1,83 @@
+package com.d4rk.android.apps.apptoolkit.app.catalog
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ClipboardHelper
+
+private data class ComponentDemo(
+    val title: String,
+    val demo: @Composable () -> Unit,
+    val code: String
+)
+
+@Composable
+fun ComponentsCatalogScreen(paddingValues: PaddingValues) {
+    val context = LocalContext.current
+    val components = listOf(
+        ComponentDemo(
+            title = "LargeVerticalSpacer",
+            demo = { LargeVerticalSpacer() },
+            code = "LargeVerticalSpacer()"
+        ),
+        ComponentDemo(
+            title = "LargeHorizontalSpacer",
+            demo = { com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer() },
+            code = "LargeHorizontalSpacer()"
+        )
+    )
+
+    Column(
+        modifier = Modifier
+            .verticalScroll(rememberScrollState())
+            .padding(paddingValues)
+            .padding(SizeConstants.LargeSize),
+        verticalArrangement = Arrangement.spacedBy(SizeConstants.LargeSize)
+    ) {
+        components.forEach { item ->
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(SizeConstants.LargeSize)) {
+                    Text(
+                        text = item.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    LargeVerticalSpacer()
+                    item.demo()
+                    LargeVerticalSpacer()
+                    Text(
+                        text = item.code,
+                        modifier = Modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Start
+                    )
+                    LargeVerticalSpacer()
+                    Button(onClick = {
+                        ClipboardHelper.copyTextToClipboard(
+                            context = context,
+                            label = item.title,
+                            text = item.code
+                        )
+                    }) {
+                        Text(text = "Copy")
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.automirrored.outlined.EventNote
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material.icons.outlined.LibraryBooks
 import com.d4rk.android.apps.apptoolkit.app.main.domain.action.MainAction
 import com.d4rk.android.apps.apptoolkit.app.main.domain.action.MainEvent
 import com.d4rk.android.apps.apptoolkit.app.main.domain.model.UiMainScreen
@@ -51,6 +52,9 @@ class MainViewModel(private val performInAppUpdateUseCase : PerformInAppUpdateUs
             screenState.successData<UiMainScreen> {
                 copy(
                     navigationDrawerItems = listOf(
+                        NavigationDrawerItem(
+                            title = com.d4rk.android.libs.apptoolkit.R.string.components_catalog , selectedIcon = Icons.Outlined.LibraryBooks
+                        ) ,
                         NavigationDrawerItem(
                             title = R.string.settings , selectedIcon = Icons.Outlined.Settings
                         ) , NavigationDrawerItem(

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
@@ -15,6 +15,7 @@ import com.d4rk.android.libs.apptoolkit.app.settings.settings.ui.SettingsActivit
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.links.AppLinks
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
+import com.d4rk.android.apps.apptoolkit.app.catalog.ComponentsCatalogActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -33,6 +34,8 @@ fun AppNavigationHost(
 
 fun handleNavigationItemClick(context : Context , item : NavigationDrawerItem , drawerState : DrawerState? = null , coroutineScope : CoroutineScope? = null) {
     when (item.title) {
+        com.d4rk.android.libs.apptoolkit.R.string.components_catalog ->
+            IntentsHelper.openActivity(context = context , activityClass = ComponentsCatalogActivity::class.java)
         com.d4rk.android.libs.apptoolkit.R.string.settings -> IntentsHelper.openActivity(context = context , activityClass = SettingsActivity::class.java)
         com.d4rk.android.libs.apptoolkit.R.string.help_and_feedback -> IntentsHelper.openActivity(context = context , activityClass = HelpActivity::class.java)
         com.d4rk.android.libs.apptoolkit.R.string.updates -> IntentsHelper.openUrl(context = context , url = AppLinks.githubChangelog(context.packageName))

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/utils/constants/NavigationRoutes.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/utils/constants/NavigationRoutes.kt
@@ -2,4 +2,5 @@ package com.d4rk.android.apps.apptoolkit.app.main.utils.constants
 
 object NavigationRoutes {
     const val ROUTE_APPS_LIST : String = "apps_list"
+    const val ROUTE_COMPONENTS_CATALOG: String = "components_catalog"
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -36,6 +36,6 @@ val appModule : Module = module {
 
     single { FetchDeveloperAppsUseCase(client = get()) }
     viewModel {
-        AppsListViewModel(fetchDeveloperAppsUseCase = get() , dispatcherProvider = get())
+        AppsListViewModel(fetchDeveloperAppsUseCase = get() , dispatcherProvider = get() , dataStore = get())
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/datastore/DataStoreNamesConstants.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/datastore/DataStoreNamesConstants.kt
@@ -32,5 +32,6 @@ open class DataStoreNamesConstants {
         const val DATA_STORE_REVIEW_DONE = "review_done"
         const val DATA_STORE_SESSION_COUNT = "session_count"
         const val DATA_STORE_REVIEW_PROMPTED = "review_prompted"
+        const val DATA_STORE_CACHED_APPS = "cached_apps"
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
@@ -219,4 +219,16 @@ open class CommonDataStore(context : Context) {
             prefs[reviewPromptedKey] = value
         }
     }
+
+    // Cached Apps List
+    private val cachedAppsKey = stringPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_CACHED_APPS)
+    val cachedApps: Flow<String?> = dataStore.data.map { prefs: Preferences ->
+        prefs[cachedAppsKey]
+    }
+
+    suspend fun saveCachedApps(json: String) {
+        dataStore.edit { prefs: MutablePreferences ->
+            prefs[cachedAppsKey] = json
+        }
+    }
 }

--- a/apptoolkit/src/main/res/values/strings.xml
+++ b/apptoolkit/src/main/res/values/strings.xml
@@ -244,6 +244,8 @@
 
     <string name="updates">Updates</string>
 
+    <string name="components_catalog">Components Catalog</string>
+
     <string name="share">Share</string>
 
     <string name="support_us">Support Us</string>


### PR DESCRIPTION
## Summary
- add string and datastore constant for caching apps
- support saving cached app list
- inject DataStore into `AppsListViewModel`
- add search bar and sort control
- create components catalog screen/activity and navigation item

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea366c418832da353c28f230f29ce