### PR TITLE
Enable periodic app usage reminders

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import com.d4rk.android.apps.apptoolkit.app.main.domain.action.MainEvent
 import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
+import com.d4rk.android.libs.apptoolkit.notifications.managers.AppUsageNotificationsManager
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.StartupActivity
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentFormHelper
@@ -51,6 +52,8 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         viewModel.onEvent(event = MainEvent.CheckForUpdates)
+        scheduleAppUsageReminder()
+        updateLastUsedTimestamp()
         checkUserConsent()
         checkInAppReview()
     }
@@ -114,6 +117,18 @@ class MainActivity : AppCompatActivity() {
                 lifecycleScope.launch { dataStore.setHasPromptedReview(true) }
             }
             dataStore.incrementSessionCount()
+        }
+    }
+
+    private fun scheduleAppUsageReminder() {
+        AppUsageNotificationsManager(context = this).scheduleAppUsageCheck(
+            notificationSummary = com.d4rk.android.libs.apptoolkit.R.string.default_notification_summary
+        )
+    }
+
+    private fun updateLastUsedTimestamp() {
+        lifecycleScope.launch {
+            dataStore.saveLastUsed(System.currentTimeMillis())
         }
     }
 }


### PR DESCRIPTION
## Summary
- trigger AppUsageNotificationsManager when the app resumes
- update last usage timestamp in the DataStore when the user opens the app

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1796f7e4832d95168b0591e85a98