### PR TITLE
Add activity lifecycle effects

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/ActivityLifecycleEffect.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/ActivityLifecycleEffect.kt
@@ -1,0 +1,33 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.effects
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.activity.ComponentActivity
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.findActivity
+
+@Composable
+fun ActivityLifecycleEffect(lifecycleEvent: Lifecycle.Event, onEvent: () -> Unit) {
+    val context = LocalContext.current
+    val activity = remember(context) { context.findActivity() }
+    val latestOnEvent by rememberUpdatedState(newValue = onEvent)
+
+    if (activity != null) {
+        DisposableEffect(activity, lifecycleEvent) {
+            val observer = LifecycleEventObserver { _, event ->
+                if (event == lifecycleEvent) {
+                    latestOnEvent()
+                }
+            }
+            activity.lifecycle.addObserver(observer)
+            onDispose {
+                activity.lifecycle.removeObserver(observer)
+            }
+        }
+    }
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityAnyEffect.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityAnyEffect.kt
@@ -1,0 +1,9 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.effects
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.Lifecycle
+
+@Composable
+fun OnActivityAnyEffect(onAny: () -> Unit) {
+    ActivityLifecycleEffect(lifecycleEvent = Lifecycle.Event.ON_ANY, onEvent = onAny)
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityCreateEffect.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityCreateEffect.kt
@@ -1,0 +1,9 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.effects
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.Lifecycle
+
+@Composable
+fun OnActivityCreateEffect(onCreate: () -> Unit) {
+    ActivityLifecycleEffect(lifecycleEvent = Lifecycle.Event.ON_CREATE, onEvent = onCreate)
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityDestroyEffect.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityDestroyEffect.kt
@@ -1,0 +1,9 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.effects
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.Lifecycle
+
+@Composable
+fun OnActivityDestroyEffect(onDestroy: () -> Unit) {
+    ActivityLifecycleEffect(lifecycleEvent = Lifecycle.Event.ON_DESTROY, onEvent = onDestroy)
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityPauseEffect.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityPauseEffect.kt
@@ -1,0 +1,9 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.effects
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.Lifecycle
+
+@Composable
+fun OnActivityPauseEffect(onPause: () -> Unit) {
+    ActivityLifecycleEffect(lifecycleEvent = Lifecycle.Event.ON_PAUSE, onEvent = onPause)
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityResumeEffect.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityResumeEffect.kt
@@ -1,0 +1,9 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.effects
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.Lifecycle
+
+@Composable
+fun OnActivityResumeEffect(onResume: () -> Unit) {
+    ActivityLifecycleEffect(lifecycleEvent = Lifecycle.Event.ON_RESUME, onEvent = onResume)
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityStartEffect.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityStartEffect.kt
@@ -1,0 +1,9 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.effects
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.Lifecycle
+
+@Composable
+fun OnActivityStartEffect(onStart: () -> Unit) {
+    ActivityLifecycleEffect(lifecycleEvent = Lifecycle.Event.ON_START, onEvent = onStart)
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityStopEffect.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/effects/OnActivityStopEffect.kt
@@ -1,0 +1,9 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.effects
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.Lifecycle
+
+@Composable
+fun OnActivityStopEffect(onStop: () -> Unit) {
+    ActivityLifecycleEffect(lifecycleEvent = Lifecycle.Event.ON_STOP, onEvent = onStop)
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/ContextExtensions.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/ContextExtensions.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.libs.apptoolkit.core.utils.extensions
 import android.content.Context
 import android.content.ContextWrapper
 import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 
 /**
  * Traverses the context chain and returns the first [ComponentActivity] if present.
@@ -10,6 +11,7 @@ import androidx.activity.ComponentActivity
 fun Context.findActivity(): ComponentActivity? {
     var ctx = this
     while (ctx is ContextWrapper) {
+        if (ctx is AppCompatActivity) return ctx
         if (ctx is ComponentActivity) return ctx
         ctx = ctx.baseContext
     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/ContextExtensions.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/ContextExtensions.kt
@@ -1,0 +1,17 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.extensions
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.ComponentActivity
+
+/**
+ * Traverses the context chain and returns the first [ComponentActivity] if present.
+ */
+fun Context.findActivity(): ComponentActivity? {
+    var ctx = this
+    while (ctx is ContextWrapper) {
+        if (ctx is ComponentActivity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
+}


### PR DESCRIPTION
## Summary
- add `Context.findActivity` extension to traverse context wrappers
- implement `ActivityLifecycleEffect` for observing activity lifecycle events
- add helpers for all major activity lifecycle events

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526306ebd0832dac9f1d555d4249a6