### PR TITLE
Implement startup screen dialog and clean bottom bar

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
@@ -81,15 +81,13 @@ fun MainScaffoldContent(drawerState : DrawerState) {
             route = NavigationRoutes.ROUTE_APPS_LIST,
             icon = Icons.Outlined.Apps,
             selectedIcon = Icons.Filled.Apps,
-            titleResId = R.string.all_apps,
             title = R.string.all_apps
         ),
         BottomBarItem(
             route = NavigationRoutes.ROUTE_FAVORITE_APPS,
             icon = Icons.Outlined.Star,
             selectedIcon = Icons.Filled.Star,
-            title = R.string.favorite_apps,
-            titleResId = R.string.favorite_apps
+            title = R.string.favorite_apps
         )
     )
 
@@ -130,14 +128,12 @@ fun MainScaffoldTabletContent() {
             route = NavigationRoutes.ROUTE_APPS_LIST,
             icon = Icons.Outlined.Apps,
             selectedIcon = Icons.Filled.Apps,
-            titleResId = R.string.all_apps,
             title = R.string.all_apps
         ),
         BottomBarItem(
             route = NavigationRoutes.ROUTE_FAVORITE_APPS,
             icon = Icons.Outlined.Star,
             selectedIcon = Icons.Filled.Star,
-            titleResId = R.string.favorite_apps,
             title = R.string.favorite_apps
         )
     )

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/AppDisplaySettingsProvider.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/AppDisplaySettingsProvider.kt
@@ -2,9 +2,11 @@ package com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers
 
 import android.content.Context
 import com.d4rk.android.libs.apptoolkit.R
+import androidx.compose.runtime.Composable
 import com.d4rk.android.libs.apptoolkit.app.settings.general.ui.GeneralSettingsActivity
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.constants.SettingsContent
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.DisplaySettingsProvider
+import com.d4rk.android.libs.apptoolkit.app.display.components.dialogs.SelectStartupScreenAlertDialog
 
 class AppDisplaySettingsProvider(val context : Context) : DisplaySettingsProvider {
     override fun openThemeSettings() {
@@ -14,4 +16,9 @@ class AppDisplaySettingsProvider(val context : Context) : DisplaySettingsProvide
     }
 
     override val supportsStartupPage: Boolean = true
+
+    @Composable
+    override fun StartupPageDialog(onDismiss: () -> Unit, onStartupSelected: (String) -> Unit) {
+        SelectStartupScreenAlertDialog(onDismiss = onDismiss, onStartupSelected = onStartupSelected)
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,8 +11,6 @@
 
     <!-- Home screen -->
     <string name="error_failed_to_fetch_our_apps">Failed to fetch our app listings</string>
-    <string name="all_apps">All Apps</string>
-    <string name="favorite_apps">Favorites</string>
 
     <!-- Help screen -->
     <string name="question_1">What is App Toolkit?</string>

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/components/dialogs/SelectStartupScreenAlertDialog.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/components/dialogs/SelectStartupScreenAlertDialog.kt
@@ -1,0 +1,96 @@
+package com.d4rk.android.libs.apptoolkit.app.display.components.dialogs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
+import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.core.ui.components.dialogs.BasicAlertDialog
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.sections.InfoMessageSection
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.MediumVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import kotlinx.coroutines.flow.firstOrNull
+
+@Composable
+fun SelectStartupScreenAlertDialog(onDismiss: () -> Unit, onStartupSelected: (String) -> Unit) {
+    val context = LocalContext.current
+    val dataStore = CommonDataStore.getInstance(context)
+    val selectedPage = remember { mutableStateOf("") }
+    val entries = stringArrayResource(id = R.array.preference_startup_entries).toList()
+    val values = stringArrayResource(id = R.array.preference_startup_values).toList()
+
+    BasicAlertDialog(
+        onDismiss = onDismiss,
+        onConfirm = {
+            onStartupSelected(selectedPage.value)
+            onDismiss()
+        },
+        icon = Icons.Outlined.Home,
+        title = stringResource(id = R.string.startup_page),
+        content = {
+            SelectStartupScreenAlertDialogContent(selectedPage, dataStore, entries, values)
+        }
+    )
+}
+
+@Composable
+fun SelectStartupScreenAlertDialogContent(
+    selectedPage: MutableState<String>,
+    dataStore: CommonDataStore,
+    startupEntries: List<String>,
+    startupValues: List<String>
+) {
+    LaunchedEffect(Unit) {
+        selectedPage.value = dataStore.getStartupPage().firstOrNull() ?: startupValues.first()
+    }
+
+    Column {
+        Text(text = stringResource(id = R.string.dialog_startup_subtitle))
+        Box(modifier = Modifier.fillMaxWidth()) {
+            LazyColumn {
+                items(startupEntries.size) { index ->
+                    Row(
+                        Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Start
+                    ) {
+                        RadioButton(
+                            selected = selectedPage.value == startupValues[index],
+                            onClick = { selectedPage.value = startupValues[index] }
+                        )
+                        Text(
+                            modifier = Modifier.padding(start = SizeConstants.SmallSize),
+                            text = startupEntries[index],
+                            style = MaterialTheme.typography.bodyMedium.merge()
+                        )
+                    }
+                }
+            }
+        }
+        MediumVerticalSpacer()
+        InfoMessageSection(message = stringResource(id = R.string.dialog_info_startup))
+    }
+
+    LaunchedEffect(selectedPage.value) {
+        dataStore.saveStartupPage(selectedPage.value)
+    }
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/domain/model/BottomBarItem.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/domain/model/BottomBarItem.kt
@@ -6,6 +6,5 @@ data class BottomBarItem(
     val route: String,
     val icon: ImageVector,
     val selectedIcon: ImageVector,
-    val title: Int,
-    val titleResId: Int
+    val title: Int
 )

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/datastore/DataStoreNamesConstants.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/datastore/DataStoreNamesConstants.kt
@@ -34,5 +34,6 @@ open class DataStoreNamesConstants {
         const val DATA_STORE_SESSION_COUNT = "session_count"
         const val DATA_STORE_REVIEW_PROMPTED = "review_prompted"
         const val DATA_STORE_FAVORITE_APPS = "favorite_apps"
+        const val DATA_STORE_STARTUP_PAGE = "startup_page"
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
@@ -59,9 +59,20 @@ open class CommonDataStore(context : Context) {
         preferences[startupKey] != false
     }
 
+    private val startupPageKey = stringPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_STARTUP_PAGE)
+    fun getStartupPage() : Flow<String> = dataStore.data.map { preferences ->
+        preferences[startupPageKey] ?: ""
+    }
+
     suspend fun saveStartup(isFirstTime : Boolean) {
         dataStore.edit { preferences : MutablePreferences ->
             preferences[startupKey] = isFirstTime
+        }
+    }
+
+    suspend fun saveStartupPage(route: String) {
+        dataStore.edit { prefs: MutablePreferences ->
+            prefs[startupPageKey] = route
         }
     }
 

--- a/apptoolkit/src/main/res/values-ar-rEG/strings.xml
+++ b/apptoolkit/src/main/res/values-ar-rEG/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">دعم غير مدفوع</string>
     <string name="web_ad">إعلان ويب</string>
     <string name="error_failed_to_load_sku_details">فشل تحميل تفاصيل SKU</string>
+    <string name="all_apps">جميع التطبيقات</string>
+    <string name="favorite_apps">المفضلة</string>
 </resources>

--- a/apptoolkit/src/main/res/values-bg-rBG/strings.xml
+++ b/apptoolkit/src/main/res/values-bg-rBG/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Безплатна подкрепа</string>
     <string name="web_ad">Уеб реклама</string>
     <string name="error_failed_to_load_sku_details">Неуспешно зареждане на SKU детайли</string>
+    <string name="all_apps">Всички приложения</string>
+    <string name="favorite_apps">Любими</string>
 </resources>

--- a/apptoolkit/src/main/res/values-bn-rBD/strings.xml
+++ b/apptoolkit/src/main/res/values-bn-rBD/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">নন-পেইড সাপোর্ট</string>
     <string name="web_ad">ওয়েব বিজ্ঞাপন</string>
     <string name="error_failed_to_load_sku_details">SKU বিবরণ লোড করতে ব্যর্থ</string>
+    <string name="all_apps">সমস্ত অ্যাপ্লিকেশন</string>
+    <string name="favorite_apps">প্রিয়</string>
 </resources>

--- a/apptoolkit/src/main/res/values-de-rDE/strings.xml
+++ b/apptoolkit/src/main/res/values-de-rDE/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Unbezahlte Unterstützung</string>
     <string name="web_ad">Webanzeige</string>
     <string name="error_failed_to_load_sku_details">Fehler beim Laden der SKU-Details</string>
+    <string name="all_apps">Alle Apps</string>
+    <string name="favorite_apps">Favoriten</string>
 </resources>

--- a/apptoolkit/src/main/res/values-es-rGQ/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rGQ/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Soporte sin pago</string>
     <string name="web_ad">Anuncio web</string>
     <string name="error_failed_to_load_sku_details">Error al cargar los detalles del SKU</string>
+    <string name="all_apps">Todas las aplicaciones</string>
+    <string name="favorite_apps">Favoritos</string>
 </resources>

--- a/apptoolkit/src/main/res/values-es-rMX/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rMX/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Soporte gratuito</string>
     <string name="web_ad">Anuncio web</string>
     <string name="error_failed_to_load_sku_details">Error al cargar los detalles del SKU</string>
+    <string name="all_apps">Todas las aplicaciones</string>
+    <string name="favorite_apps">Favoritos</string>
 </resources>

--- a/apptoolkit/src/main/res/values-fil-rPH/strings.xml
+++ b/apptoolkit/src/main/res/values-fil-rPH/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Hindi Bayad na Suporta</string>
     <string name="web_ad">Web Ad</string>
     <string name="error_failed_to_load_sku_details">Nabigong i-load ang mga detalye ng SKU</string>
+    <string name="all_apps">Lahat ng mga app</string>
+    <string name="favorite_apps">Mga Paborito</string>
 </resources>

--- a/apptoolkit/src/main/res/values-fr-rFR/strings.xml
+++ b/apptoolkit/src/main/res/values-fr-rFR/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Support non payant</string>
     <string name="web_ad">Publicité Web</string>
     <string name="error_failed_to_load_sku_details">Échec du chargement des détails du SKU</string>
+    <string name="all_apps">Toutes les applications</string>
+    <string name="favorite_apps">Favoris</string>
 </resources>

--- a/apptoolkit/src/main/res/values-hi-rIN/strings.xml
+++ b/apptoolkit/src/main/res/values-hi-rIN/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">गैर-भुगतान समर्थन</string>
     <string name="web_ad">वेब विज्ञापन</string>
     <string name="error_failed_to_load_sku_details">SKU विवरण लोड करने में विफल</string>
+    <string name="all_apps">सभी ऐप्स</string>
+    <string name="favorite_apps">पसंदीदा</string>
 </resources>

--- a/apptoolkit/src/main/res/values-hu-rHU/strings.xml
+++ b/apptoolkit/src/main/res/values-hu-rHU/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Nem fizetett támogatás</string>
     <string name="web_ad">Webes hirdetés</string>
     <string name="error_failed_to_load_sku_details">Nem sikerült betölteni az SKU részleteit</string>
+    <string name="all_apps">Minden alkalmazás</string>
+    <string name="favorite_apps">Kedvencek</string>
 </resources>

--- a/apptoolkit/src/main/res/values-in-rID/strings.xml
+++ b/apptoolkit/src/main/res/values-in-rID/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Dukungan tidak berbayar</string>
     <string name="web_ad">Iklan web</string>
     <string name="error_failed_to_load_sku_details">Gagal memuat detail SKU</string>
+    <string name="all_apps">Semua aplikasi</string>
+    <string name="favorite_apps">Favorit</string>
 </resources>

--- a/apptoolkit/src/main/res/values-it-rIT/strings.xml
+++ b/apptoolkit/src/main/res/values-it-rIT/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Supporto non a pagamento</string>
     <string name="web_ad">Annuncio web</string>
     <string name="error_failed_to_load_sku_details">Impossibile caricare i dettagli dello SKU</string>
+    <string name="all_apps">Tutte le app</string>
+    <string name="favorite_apps">Preferiti</string>
 </resources>

--- a/apptoolkit/src/main/res/values-ja-rJP/strings.xml
+++ b/apptoolkit/src/main/res/values-ja-rJP/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">無償サポート</string>
     <string name="web_ad">ウェブ広告</string>
     <string name="error_failed_to_load_sku_details">SKU の詳細を読み込めませんでした</string>
+    <string name="all_apps">すべてのアプリ</string>
+    <string name="favorite_apps">お気に入り</string>
 </resources>

--- a/apptoolkit/src/main/res/values-ko-rKR/strings.xml
+++ b/apptoolkit/src/main/res/values-ko-rKR/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">무료 지원</string>
     <string name="web_ad">웹 광고</string>
     <string name="error_failed_to_load_sku_details">SKU 세부 정보를 로드하지 못했습니다.</string>
+    <string name="all_apps">모든 앱</string>
+    <string name="favorite_apps">즐겨 찾기</string>
 </resources>

--- a/apptoolkit/src/main/res/values-pl-rPL/strings.xml
+++ b/apptoolkit/src/main/res/values-pl-rPL/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Wsparcie bezpłatne</string>
     <string name="web_ad">Reklama internetowa</string>
     <string name="error_failed_to_load_sku_details">Nie udało się załadować szczegółów SKU</string>
+    <string name="all_apps">Wszystkie aplikacje</string>
+    <string name="favorite_apps">Ulubione</string>
 </resources>

--- a/apptoolkit/src/main/res/values-pt-rBR/strings.xml
+++ b/apptoolkit/src/main/res/values-pt-rBR/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Suporte não pago</string>
     <string name="web_ad">Anúncio na web</string>
     <string name="error_failed_to_load_sku_details">Falha ao carregar os detalhes do SKU</string>
+    <string name="all_apps">Todos os aplicativos</string>
+    <string name="favorite_apps">Favoritos</string>
 </resources>

--- a/apptoolkit/src/main/res/values-ro-rRO/strings.xml
+++ b/apptoolkit/src/main/res/values-ro-rRO/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Suport neplătit</string>
     <string name="web_ad">Reclamă web</string>
     <string name="error_failed_to_load_sku_details">Nu s-au putut încărca detaliile SKU</string>
+    <string name="all_apps">Toate aplicațiile</string>
+    <string name="favorite_apps">Favorite</string>
 </resources>

--- a/apptoolkit/src/main/res/values-ru-rRU/strings.xml
+++ b/apptoolkit/src/main/res/values-ru-rRU/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Бесплатная поддержка</string>
     <string name="web_ad">Веб-реклама</string>
     <string name="error_failed_to_load_sku_details">Не удалось загрузить сведения о SKU</string>
+    <string name="all_apps">Все приложения</string>
+    <string name="favorite_apps">Фавориты</string>
 </resources>

--- a/apptoolkit/src/main/res/values-sv-rSE/strings.xml
+++ b/apptoolkit/src/main/res/values-sv-rSE/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Obetalt stöd</string>
     <string name="web_ad">Webbannons</string>
     <string name="error_failed_to_load_sku_details">Det gick inte att läsa in SKU-detaljer</string>
+    <string name="all_apps">Alla appar</string>
+    <string name="favorite_apps">Favoriter</string>
 </resources>

--- a/apptoolkit/src/main/res/values-th-rTH/strings.xml
+++ b/apptoolkit/src/main/res/values-th-rTH/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">การสนับสนุนแบบไม่ชำระเงิน</string>
     <string name="web_ad">โฆษณาเว็บ</string>
     <string name="error_failed_to_load_sku_details">ไม่สามารถโหลดรายละเอียด SKU ได้</string>
+    <string name="all_apps">แอพทั้งหมด</string>
+    <string name="favorite_apps">รายการโปรด</string>
 </resources>

--- a/apptoolkit/src/main/res/values-tr-rTR/strings.xml
+++ b/apptoolkit/src/main/res/values-tr-rTR/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Ücretsiz destek</string>
     <string name="web_ad">Web Reklamı</string>
     <string name="error_failed_to_load_sku_details">SKU ayrıntıları yüklenemedi</string>
+    <string name="all_apps">Tüm uygulamalar</string>
+    <string name="favorite_apps">Favoriler</string>
 </resources>

--- a/apptoolkit/src/main/res/values-uk-rUA/strings.xml
+++ b/apptoolkit/src/main/res/values-uk-rUA/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Безкоштовна підтримка</string>
     <string name="web_ad">Веб-реклама</string>
     <string name="error_failed_to_load_sku_details">Не вдалося завантажити деталі SKU</string>
+    <string name="all_apps">Всі програми</string>
+    <string name="favorite_apps">Фаворити</string>
 </resources>

--- a/apptoolkit/src/main/res/values-ur-rPK/strings.xml
+++ b/apptoolkit/src/main/res/values-ur-rPK/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">بغیر معاوضہ سپورٹ</string>
     <string name="web_ad">ویب اشتہار</string>
     <string name="error_failed_to_load_sku_details">SKU تفصیلات لوڈ کرنے میں ناکام</string>
+    <string name="all_apps">تمام ایپس</string>
+    <string name="favorite_apps">پسندیدہ</string>
 </resources>

--- a/apptoolkit/src/main/res/values-vi-rVN/strings.xml
+++ b/apptoolkit/src/main/res/values-vi-rVN/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">Hỗ trợ không trả phí</string>
     <string name="web_ad">Quảng cáo web</string>
     <string name="error_failed_to_load_sku_details">Không thể tải chi tiết SKU</string>
+    <string name="all_apps">Tất cả các ứng dụng</string>
+    <string name="favorite_apps">Yêu thích</string>
 </resources>

--- a/apptoolkit/src/main/res/values-zh-rTW/strings.xml
+++ b/apptoolkit/src/main/res/values-zh-rTW/strings.xml
@@ -278,4 +278,6 @@
     <string name="non_paid_support">非付費支持</string>
     <string name="web_ad">網頁廣告</string>
     <string name="error_failed_to_load_sku_details">載入 SKU 詳細資料失敗</string>
+    <string name="all_apps">所有应用程序</string>
+    <string name="favorite_apps">最爱</string>
 </resources>

--- a/apptoolkit/src/main/res/values/arrays.xml
+++ b/apptoolkit/src/main/res/values/arrays.xml
@@ -57,4 +57,14 @@
         <item>ur</item>
         <item>vi</item>
     </string-array>
+
+    <string-array name="preference_startup_entries">
+        <item>@string/all_apps</item>
+        <item>@string/favorite_apps</item>
+    </string-array>
+
+    <string-array name="preference_startup_values">
+        <item>apps_list</item>
+        <item>favorite_apps</item>
+    </string-array>
 </resources>

--- a/apptoolkit/src/main/res/values/strings.xml
+++ b/apptoolkit/src/main/res/values/strings.xml
@@ -280,4 +280,7 @@
     <string name="non_paid_support">Non-Paid Support</string>
     <string name="web_ad">Web Ad</string>
     <string name="error_failed_to_load_sku_details">Failed to load SKU details</string>
+
+    <string name="all_apps">All Apps</string>
+    <string name="favorite_apps">Favorites</string>
 </resources>


### PR DESCRIPTION
## Summary
- add new startup page selection dialog
- support saving/loading startup page in datastore
- add translations for bottom bar strings
- remove unused titleResId from `BottomBarItem`
- wire up dialog via `AppDisplaySettingsProvider`

## Testing
- `./gradlew tasks --all` *(fails: Android SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548b3120fc832dbc87f637d15cf649