### PR TITLE
Add unit tests for app list screen with JUnit5 setup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(notation = libs.plugins.kotlin.android)
     alias(notation = libs.plugins.compose.compiler)
     alias(notation = libs.plugins.about.libraries)
+    alias(notation = libs.plugins.mannodermaus)
     alias(notation = libs.plugins.googlePlayServices)
     alias(notation = libs.plugins.googleFirebase)
     alias(notation = libs.plugins.kotlin.serialization)
@@ -107,8 +108,16 @@ android {
             excludes.add("META-INF/io.netty.versions.properties")
         }
     }
+
+    testOptions {
+        unitTests.all {
+            it.useJUnitPlatform()
+        }
+    }
 }
 
 dependencies {
     implementation(dependencyNotation = project(path = ":apptoolkit"))
+
+    testImplementation(libs.bundles.testing)
 }

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/MainDispatcherExtension.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/MainDispatcherExtension.kt
@@ -1,0 +1,24 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherExtension : BeforeEachCallback, AfterEachCallback {
+    val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    override fun beforeEach(context: ExtensionContext?) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
@@ -1,0 +1,52 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list
+
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import kotlinx.coroutines.flow.flow
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class TestAppsListViewModel : TestAppsListViewModelBase() {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = MainDispatcherExtension()
+    }
+
+    @Test
+    fun `fetch apps - success list`() {
+        val apps = listOf(
+            AppInfo("App1", "pkg1", "url1"),
+            AppInfo("App2", "pkg2", "url2")
+        )
+        val flow = flow {
+            emit(DataState.Loading<List<AppInfo>, Error>())
+            emit(DataState.Success<List<AppInfo>, Error>(apps))
+        }
+        setup(fetchFlow = flow)
+        viewModel.uiState.testSuccess(expectedSize = apps.size)
+    }
+
+    @Test
+    fun `fetch apps - empty list`() {
+        val flow = flow {
+            emit(DataState.Loading<List<AppInfo>, Error>())
+            emit(DataState.Success<List<AppInfo>, Error>(emptyList()))
+        }
+        setup(fetchFlow = flow)
+        viewModel.uiState.testEmpty()
+    }
+
+    @Test
+    fun `toggle favorite`() {
+        val apps = listOf(AppInfo("App", "pkg", "url"))
+        val flow = flow {
+            emit(DataState.Loading<List<AppInfo>, Error>())
+            emit(DataState.Success<List<AppInfo>, Error>(apps))
+        }
+        setup(fetchFlow = flow)
+        toggleAndAssert(packageName = "pkg", expected = true)
+        toggleAndAssert(packageName = "pkg", expected = false)
+    }
+}

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -1,0 +1,73 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list
+
+import app.cash.turbine.test
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.AppsListViewModel
+import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+open class TestAppsListViewModelBase {
+
+    protected lateinit var dispatcherProvider: TestDispatchers
+    protected lateinit var viewModel: AppsListViewModel
+    private lateinit var fetchUseCase: FetchDeveloperAppsUseCase
+    private lateinit var dataStore: DataStore
+
+    protected fun setup(fetchFlow: Flow<DataState<List<AppInfo>, RootError>>, initialFavorites: Set<String> = emptySet()) {
+        val extension = MainDispatcherExtension()
+        dispatcherProvider = TestDispatchers(extension.testDispatcher)
+        fetchUseCase = mockk()
+        dataStore = mockk(relaxed = true)
+        every { dataStore.favoriteApps } returns MutableStateFlow(initialFavorites)
+        coEvery { fetchUseCase.invoke() } returns fetchFlow
+
+        viewModel = AppsListViewModel(fetchUseCase, dispatcherProvider, dataStore)
+    }
+
+    protected fun Flow<UiStateScreen<UiHomeScreen>>.testSuccess(expectedSize: Int) = runTest {
+        this@testSuccess.test {
+            // First emission from init loading might be Loading or IsLoading - the initial state
+            val first = awaitItem()
+            // Initial state is IsLoading from ViewModel's init
+            assertTrue(first.screenState is ScreenState.IsLoading)
+
+            val second = awaitItem()
+            assertTrue(second.screenState is ScreenState.Success)
+            assertThat(second.data?.apps?.size).isEqualTo(expectedSize)
+        }
+    }
+
+    protected fun Flow<UiStateScreen<UiHomeScreen>>.testEmpty() = runTest {
+        this@testEmpty.test {
+            val first = awaitItem()
+            assertTrue(first.screenState is ScreenState.IsLoading)
+
+            val second = awaitItem()
+            assertTrue(second.screenState is ScreenState.NoData)
+        }
+    }
+
+    protected fun toggleAndAssert(packageName: String, expected: Boolean) = runTest {
+        viewModel.toggleFavorite(packageName)
+        val favorites = viewModel.favorites.value
+        assertThat(favorites.contains(packageName)).isEqualTo(expected)
+    }
+}

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/TestDispatchers.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/TestDispatchers.kt
@@ -1,0 +1,17 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list
+
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+
+class TestDispatchers(val mTestDispatcher: TestDispatcher = StandardTestDispatcher()) : DispatcherProvider {
+    override val main: CoroutineDispatcher
+        get() = mTestDispatcher
+    override val io: CoroutineDispatcher
+        get() = mTestDispatcher
+    override val default: CoroutineDispatcher
+        get() = mTestDispatcher
+    override val unconfined: CoroutineDispatcher
+        get() = mTestDispatcher
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(notation = libs.plugins.android.library) apply false
     alias(notation = libs.plugins.compose.compiler) apply false
     alias(notation = libs.plugins.about.libraries) apply true
+    alias(notation = libs.plugins.mannodermaus) apply false
     alias(notation = libs.plugins.googlePlayServices) apply false
     alias(notation = libs.plugins.googleFirebase) apply false
     alias(notation = libs.plugins.kotlin.serialization) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,23 @@ userMessagingPlatform = "3.2.0"
 workRuntimeKtx = "2.10.2"
 google-services = "4.4.2"
 google-firebase-crashlytics = "3.0.4"
+junitJupiter = "5.10.1"
+mockk = "1.12.5"
+kotlinxCoroutinesTest = "1.10.2"
+turbine = "1.1.0"
+junit = "4.13.2"
+testRunner = "1.6.2"
+junitVersion = "1.2.1"
+junittest = "3.6.1"
+mannodermaus = "1.9.3.0"
+willow = "0.26.1"
+jupiter = "5.9.3"
+testCorutines = "1.10.1"
+testTurbine = "0.7.0"
+testManifest = "1.7.8"
+junitKtx = "1.2.1"
+truth = "1.6.0"
+uiTestJunit4Android = "1.7.8"
 
 [libraries]
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
@@ -90,6 +107,35 @@ coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
 user-messaging-platform = { module = "com.google.android.ump:user-messaging-platform", version.ref = "userMessagingPlatform" }
 
+# Testing
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junitJupiter" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "testRunner" }
+androidx-test-orchestrator = { group = "androidx.test", name = "orchestrator", version.ref = "testRunner" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "junittest" }
+jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiter" }
+jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jupiter" }
+jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "jupiter" }
+mockk-api = { module = "io.mockk:mockk", version.ref = "mockk" }
+mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
+test-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "testCorutines" }
+test-turbine = { module = "app.cash.turbine:turbine", version.ref = "testTurbine" }
+test-koin = { module = "io.insert-koin:koin-test", version.ref = "koin" }
+test-koin-junit4 = { module = "io.insert-koin:koin-test-junit4", version.ref = "koin" }
+test-koin-junit5 = { module = "io.insert-koin:koin-test-junit5", version.ref = "koin" }
+instrumentation-koin-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
+instrumentation-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "testManifest" }
+willow-assert = { module = "com.willowtreeapps.assertk:assertk", version.ref = "willow" }
+androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "junitKtx" }
+androidx-ui-test-junit4-android = { group = "androidx.compose.ui", name = "ui-test-junit4-android", version.ref = "uiTestJunit4Android" }
+androidx-truth = { module = "androidx.test.ext:truth", version.ref = "truth" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
@@ -99,10 +145,43 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 about-libraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
 googlePlayServices = { id = "com.google.gms.google-services", version.ref = "google-services" }
 googleFirebase = { id = "com.google.firebase.crashlytics", version.ref = "google-firebase-crashlytics" }
+mannodermaus = { id = "de.mannodermaus.android-junit5", version.ref = "mannodermaus" }
 
 [bundles]
 koin = [
     "koin-core",
     "koin-compose-viewmodel",
     "koin-android"
+]
+testing = [
+    "junit",
+    "jupiter-api",
+    "jupiter-engine",
+    "jupiter-params",
+    "willow-assert",
+    "mockk-api",
+    "mockk-android",
+    "test-kotlin-coroutines",
+    "test-turbine",
+    "test-koin",
+    "test-koin-junit4",
+    "test-koin-junit5"
+]
+
+androidTesting = [
+    "androidx-espresso-core",
+    "androidx-junit",
+    "androidx-junit-ktx",
+    "androidx-truth",
+    "androidx-test-runner",
+    "androidx-test-orchestrator",
+    "mockk-api",
+    "test-kotlin-coroutines",
+    "instrumentation-koin-compose",
+    "test-koin",
+    "willow-assert",
+    "test-turbine",
+    "instrumentation-test-manifest",
+    "androidx-ui-test-junit4-android",
+    "androidx-ui-test-junit4"
 ]


### PR DESCRIPTION
## Summary
- expand version catalog with testing bundles and JUnit5 plugin
- apply JUnit5 plugin and use bundled testing libraries
- implement generic `TestDispatchers` helper
- update app list ViewModel tests to use assertk

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629651f1b0832d909c5cdfc9aaa850