### PR TITLE
Add IssueReporter unit tests

### DIFF
--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -125,6 +125,7 @@ dependencies {
     // About
     api(dependencyNotation = libs.aboutlibraries.compose.m3)
     testImplementation(dependencyNotation = libs.bundles.testing)
+    testImplementation(dependencyNotation = libs.ktor.client.mock)
     androidTestImplementation(dependencyNotation = libs.bundles.androidTesting)
     debugImplementation(dependencyNotation = libs.androidx.ui.test.manifest)
     api(dependencyNotation = libs.core)

--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(notation = libs.plugins.android.library)
     alias(notation = libs.plugins.kotlin.android)
+    alias(notation = libs.plugins.mannodermaus)
     alias(notation = libs.plugins.compose.compiler)
     alias(notation = libs.plugins.about.libraries)
     alias(notation = libs.plugins.kotlin.serialization)
@@ -40,6 +41,11 @@ android {
 
     buildFeatures {
         compose = true
+    }
+    testOptions {
+        unitTests.all {
+            it.useJUnitPlatform()
+        }
     }
 }
 
@@ -118,6 +124,9 @@ dependencies {
 
     // About
     api(dependencyNotation = libs.aboutlibraries.compose.m3)
+    testImplementation(dependencyNotation = libs.bundles.testing)
+    androidTestImplementation(dependencyNotation = libs.bundles.androidTesting)
+    debugImplementation(dependencyNotation = libs.androidx.ui.test.manifest)
     api(dependencyNotation = libs.core)
 }
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/MainDispatcherExtension.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/MainDispatcherExtension.kt
@@ -1,0 +1,24 @@
+package com.d4rk.android.libs.apptoolkit.app.issuereporter
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherExtension : BeforeEachCallback, AfterEachCallback {
+    val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    override fun beforeEach(context: ExtensionContext?) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        Dispatchers.resetMain()
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/TestDispatchers.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/TestDispatchers.kt
@@ -1,0 +1,17 @@
+package com.d4rk.android.libs.apptoolkit.app.issuereporter
+
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+
+class TestDispatchers(val mTestDispatcher: TestDispatcher = StandardTestDispatcher()) : DispatcherProvider {
+    override val main: CoroutineDispatcher
+        get() = mTestDispatcher
+    override val io: CoroutineDispatcher
+        get() = mTestDispatcher
+    override val default: CoroutineDispatcher
+        get() = mTestDispatcher
+    override val unconfined: CoroutineDispatcher
+        get() = mTestDispatcher
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/TestIssueReporterRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/TestIssueReporterRepository.kt
@@ -1,0 +1,61 @@
+package com.d4rk.android.libs.apptoolkit.app.issuereporter.data
+
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.IssueReportResult
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.Report
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.ExtraInfo
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class TestIssueReporterRepository {
+
+    @Test
+    fun `sendReport returns success`() = runTest {
+        println("\uD83D\uDE80 [TEST] repository success")
+        var capturedRequest: HttpRequestData? = null
+        val engine = MockEngine { request ->
+            capturedRequest = request
+            val body = """{"html_url":"https://example.com/issue/1"}"""
+            respond(content = body, status = HttpStatusCode.Created)
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json() }
+        }
+        val repository = IssueReporterRepository(client)
+        val report = Report("title", "desc", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), "me@test.com")
+        val target = GithubTarget("user", "repo")
+        val result = repository.sendReport(report, target, token = "token123")
+
+        assertIs<IssueReportResult.Success>(result)
+        assertEquals("https://example.com/issue/1", result.url)
+        assertEquals("Bearer token123", capturedRequest?.headers?.get(HttpHeaders.Authorization))
+        println("\uD83C\uDFC1 [TEST DONE] repository success")
+    }
+
+    @Test
+    fun `sendReport returns error`() = runTest {
+        println("\uD83D\uDE80 [TEST] repository error")
+        val engine = MockEngine { respond("fail", HttpStatusCode.BadRequest) }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
+        val repository = IssueReporterRepository(client)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val target = GithubTarget("user", "repo")
+        val result = repository.sendReport(report, target)
+
+        assertIs<IssueReportResult.Error>(result)
+        assertEquals(HttpStatusCode.BadRequest, result.status)
+        assertEquals("fail", result.message)
+        println("\uD83C\uDFC1 [TEST DONE] repository error")
+    }
+}
+

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/TestIssueReporterRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/TestIssueReporterRepository.kt
@@ -13,9 +13,10 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import org.junit.jupiter.api.Test
 
 class TestIssueReporterRepository {
 
@@ -36,9 +37,9 @@ class TestIssueReporterRepository {
         val target = GithubTarget("user", "repo")
         val result = repository.sendReport(report, target, token = "token123")
 
-        assertIs<IssueReportResult.Success>(result)
-        assertEquals("https://example.com/issue/1", result.url)
-        assertEquals("Bearer token123", capturedRequest?.headers?.get(HttpHeaders.Authorization))
+        assertThat(result).isInstanceOf(IssueReportResult.Success::class)
+        assertThat((result as IssueReportResult.Success).url).isEqualTo("https://example.com/issue/1")
+        assertThat(capturedRequest?.headers?.get(HttpHeaders.Authorization)).isEqualTo("Bearer token123")
         println("\uD83C\uDFC1 [TEST DONE] repository success")
     }
 
@@ -52,9 +53,10 @@ class TestIssueReporterRepository {
         val target = GithubTarget("user", "repo")
         val result = repository.sendReport(report, target)
 
-        assertIs<IssueReportResult.Error>(result)
-        assertEquals(HttpStatusCode.BadRequest, result.status)
-        assertEquals("fail", result.message)
+        assertThat(result).isInstanceOf(IssueReportResult.Error::class)
+        val error = result as IssueReportResult.Error
+        assertThat(error.status).isEqualTo(HttpStatusCode.BadRequest)
+        assertThat(error.message).isEqualTo("fail")
         println("\uD83C\uDFC1 [TEST DONE] repository error")
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModel.kt
@@ -1,0 +1,97 @@
+package com.d4rk.android.libs.apptoolkit.app.issuereporter.ui
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.content.pm.PackageInfo
+import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.actions.IssueReporterEvent
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.ScreenMessageType
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.MainDispatcherExtension
+import io.mockk.every
+import io.mockk.mockk
+
+class TestIssueReporterViewModel : TestIssueReporterViewModelBase() {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = MainDispatcherExtension()
+    }
+
+    @Test
+    fun `update fields`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] update fields")
+        val engine = MockEngine { respond("", HttpStatusCode.Created) }
+        setup(engine, testDispatcher = dispatcherExtension.testDispatcher)
+
+        viewModel.onEvent(IssueReporterEvent.UpdateTitle("Bug"))
+        viewModel.onEvent(IssueReporterEvent.UpdateDescription("Desc"))
+        viewModel.onEvent(IssueReporterEvent.UpdateEmail("me@test.com"))
+        viewModel.onEvent(IssueReporterEvent.SetAnonymous(false))
+
+        val data = viewModel.uiState.value.data!!
+        assert(data.title == "Bug")
+        assert(data.description == "Desc")
+        assert(data.email == "me@test.com")
+        assert(!data.anonymous)
+        println("\uD83C\uDFC1 [TEST DONE] update fields")
+    }
+
+    @Test
+    fun `send report invalid`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] send report invalid")
+        val engine = MockEngine { respond("", HttpStatusCode.Created) }
+        setup(engine, testDispatcher = dispatcherExtension.testDispatcher)
+        val context = mockk<Context>(relaxed = true)
+
+        viewModel.onEvent(IssueReporterEvent.Send(context))
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        val snackbar = state.snackbar!!
+        assert(snackbar.isError)
+        val msg = snackbar.message as UiTextHelper.StringResource
+        assert(msg.resourceId == R.string.error_invalid_report)
+        assert(state.screenState is ScreenState.IsLoading == false)
+        println("\uD83C\uDFC1 [TEST DONE] send report invalid")
+    }
+
+    @Test
+    fun `send report success`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] send report success")
+        val engine = MockEngine { respond("""{\"html_url\":\"https://ex.com/1\"}""", HttpStatusCode.Created) }
+        setup(engine, githubToken = "token", testDispatcher = dispatcherExtension.testDispatcher)
+        val packageInfo = PackageInfo().apply { versionCode = 1; versionName = "1" }
+        val pm = mockk<PackageManager>()
+        every { pm.getPackageInfo(any<String>(), any<Int>()) } returns packageInfo
+        val context = mockk<Context>()
+        every { context.packageManager } returns pm
+        every { context.packageName } returns "pkg"
+
+        viewModel.onEvent(IssueReporterEvent.UpdateTitle("Bug"))
+        viewModel.onEvent(IssueReporterEvent.UpdateDescription("Desc"))
+        viewModel.onEvent(IssueReporterEvent.UpdateEmail("me@test.com"))
+        viewModel.onEvent(IssueReporterEvent.Send(context))
+
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        val snackbar = state.snackbar!!
+        assert(!snackbar.isError)
+        assert((snackbar.message as UiTextHelper.StringResource).resourceId == R.string.snack_report_success)
+        assert(state.data?.issueUrl == "https://ex.com/1")
+        assert(state.screenState is ScreenState.Success)
+        println("\uD83C\uDFC1 [TEST DONE] send report success")
+    }
+}
+

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModelBase.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModelBase.kt
@@ -1,0 +1,36 @@
+package com.d4rk.android.libs.apptoolkit.app.issuereporter.ui
+
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.TestDispatchers
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.ui.IssueReporterViewModel
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+
+@OptIn(ExperimentalCoroutinesApi::class)
+open class TestIssueReporterViewModelBase {
+
+    protected lateinit var dispatcherProvider: TestDispatchers
+    protected lateinit var viewModel: IssueReporterViewModel
+
+    protected fun setup(
+        engine: MockEngine,
+        githubTarget: GithubTarget = GithubTarget("user", "repo"),
+        githubToken: String = "",
+        testDispatcher: TestDispatcher
+    ) {
+        println("\uD83E\uDDEA [SETUP] githubTarget=$githubTarget tokenProvided=${githubToken.isNotBlank()}")
+        dispatcherProvider = TestDispatchers(testDispatcher)
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+        viewModel = IssueReporterViewModel(dispatcherProvider, client, githubTarget, githubToken)
+        println("\u2705 [SETUP] ViewModel initialized")
+    }
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,6 +72,7 @@ ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negoti
 ktor-client-logging = { module = "io.ktor:ktor-client-logging" }
 ktor-client-serialization = { module = "io.ktor:ktor-client-serialization" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }


### PR DESCRIPTION
## Summary
- add JUnit5 configuration and test dependencies for the library module
- implement repository and view model tests for IssueReporter
- include dispatcher utilities for tests
- fix test package names and add debug logging

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e9d4f674832db16cb401c7ce476e