### PR TITLE
Add edge case tests for viewmodels

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/TestOnboardingViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/TestOnboardingViewModel.kt
@@ -18,4 +18,19 @@ class TestOnboardingViewModel {
         viewModel.currentTabIndex = 1
         assertThat(viewModel.currentTabIndex).isEqualTo(1)
     }
+
+    @Test
+    fun `setting negative tab index`() {
+        val viewModel = OnboardingViewModel()
+        viewModel.currentTabIndex = -1
+        assertThat(viewModel.currentTabIndex).isEqualTo(-1)
+    }
+
+    @Test
+    fun `resetting tab index to default`() {
+        val viewModel = OnboardingViewModel()
+        viewModel.currentTabIndex = 2
+        viewModel.currentTabIndex = 0
+        assertThat(viewModel.currentTabIndex).isEqualTo(0)
+    }
 }


### PR DESCRIPTION
## Summary
- add extra OnboardingViewModel tests for negative indices and reset
- extend PermissionsViewModel tests for provider failure and error dismissal

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868431ed688832d88ee81812cbb3099