### PR TITLE
Add utility tests

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/utils/TestCleanHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/utils/TestCleanHelper.kt
@@ -1,0 +1,39 @@
+package com.d4rk.android.libs.apptoolkit.app.advanced.utils
+
+import android.content.Context
+import android.widget.Toast
+import com.d4rk.android.libs.apptoolkit.R
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class TestCleanHelper {
+
+    @Test
+    fun `clearApplicationCache deletes cache directories`() {
+        val dir1 = createTempDir()
+        val dir2 = createTempDir()
+        val dir3 = createTempDir()
+
+        val context = mockk<Context>()
+        every { context.cacheDir } returns dir1
+        every { context.codeCacheDir } returns dir2
+        every { context.filesDir } returns dir3
+        every { context.getString(R.string.cache_cleared_success) } returns "success"
+
+        mockkStatic(Toast::class)
+        val toast = mockk<Toast>(relaxed = true)
+        every { Toast.makeText(context, "success", Toast.LENGTH_SHORT) } returns toast
+
+        CleanHelper.clearApplicationCache(context)
+
+        assertFalse(dir1.exists())
+        assertFalse(dir2.exists())
+        assertFalse(dir3.exists())
+        verify { Toast.makeText(context, "success", Toast.LENGTH_SHORT) }
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/utils/helpers/TestCrashlyticsOnboardingStateManager.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/utils/helpers/TestCrashlyticsOnboardingStateManager.kt
@@ -1,0 +1,16 @@
+package com.d4rk.android.libs.apptoolkit.app.oboarding.utils.helpers
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TestCrashlyticsOnboardingStateManager {
+
+    @Test
+    fun `open and dismiss dialog update state`() {
+        CrashlyticsOnboardingStateManager.openDialog()
+        assertTrue(CrashlyticsOnboardingStateManager.showCrashlyticsDialog)
+        CrashlyticsOnboardingStateManager.dismissDialog()
+        assertFalse(CrashlyticsOnboardingStateManager.showCrashlyticsDialog)
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestClipboardHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestClipboardHelper.kt
@@ -1,0 +1,38 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.helpers
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TestClipboardHelper {
+    @Test
+    fun `copyTextToClipboard sets primary clip and executes callback when appropriate`() {
+        val manager = mockk<ClipboardManager>()
+        val context = mockk<Context>()
+        every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns manager
+        val clipSlot = slot<ClipData>()
+        justRun { manager.setPrimaryClip(capture(clipSlot)) }
+
+        var callbackExecuted = false
+        ClipboardHelper.copyTextToClipboard(context, "label", "text") { callbackExecuted = true }
+
+        verify { manager.setPrimaryClip(any()) }
+        assertEquals("text", clipSlot.captured.getItemAt(0).text)
+
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+            assertTrue(callbackExecuted)
+        } else {
+            assertFalse(callbackExecuted)
+        }
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestIntentsHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestIntentsHelper.kt
@@ -1,0 +1,41 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.helpers
+
+import android.content.Context
+import android.content.Intent
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TestIntentsHelper {
+
+    @Test
+    fun `openUrl starts ACTION_VIEW intent`() {
+        val context = mockk<Context>()
+        val intentSlot = slot<Intent>()
+        justRun { context.startActivity(capture(intentSlot)) }
+
+        IntentsHelper.openUrl(context, "https://example.com")
+
+        val intent = intentSlot.captured
+        assertEquals(Intent.ACTION_VIEW, intent.action)
+        assertEquals("https://example.com", intent.data.toString())
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+
+    @Test
+    fun `openActivity starts activity with new task flag`() {
+        val context = mockk<Context>()
+        val intentSlot = slot<Intent>()
+        justRun { context.startActivity(capture(intentSlot)) }
+
+        IntentsHelper.openActivity(context, String::class.java)
+
+        val intent = intentSlot.captured
+        assertEquals(String::class.java.name, intent.component?.className)
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestPermissionsHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestPermissionsHelper.kt
@@ -1,0 +1,50 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.helpers
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.permissions.PermissionsConstants
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TestPermissionsHelper {
+
+    @Test
+    fun `hasNotificationPermission parses permission state`() {
+        val context = mockk<Context>()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mockkStatic(ContextCompat::class)
+            every { ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) } returns PackageManager.PERMISSION_GRANTED
+            assertTrue(PermissionsHelper.hasNotificationPermission(context))
+            every { ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) } returns PackageManager.PERMISSION_DENIED
+            assertFalse(PermissionsHelper.hasNotificationPermission(context))
+        } else {
+            assertTrue(PermissionsHelper.hasNotificationPermission(context))
+        }
+    }
+
+    @Test
+    fun `requestNotificationPermission delegates to ActivityCompat when needed`() {
+        val activity = mockk<Activity>()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mockkStatic(ActivityCompat::class)
+            justRun { ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.POST_NOTIFICATIONS), PermissionsConstants.REQUEST_CODE_NOTIFICATION_PERMISSION) }
+            PermissionsHelper.requestNotificationPermission(activity)
+            verify { ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.POST_NOTIFICATIONS), PermissionsConstants.REQUEST_CODE_NOTIFICATION_PERMISSION) }
+        } else {
+            mockkStatic(ActivityCompat::class)
+            PermissionsHelper.requestNotificationPermission(activity)
+            verify(exactly = 0) { ActivityCompat.requestPermissions(any(), any(), any()) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for cache clearing logic
- test clipboard helper
- test crashlytics onboarding state
- test intent building helpers
- test permissions helper

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cfc80774832d901232254d4081c0