### PR TITLE
Add extensive tests for settings and issue reporter

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
@@ -70,4 +70,33 @@ class TestGeneralSettingsViewModel {
         state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
     }
+
+    @Test
+    fun `multiple load calls update key`() = runTest(dispatcherExtension.testDispatcher) {
+        val viewModel = GeneralSettingsViewModel()
+        viewModel.onEvent(GeneralSettingsEvent.Load("one"))
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        var state = viewModel.uiState.value
+        assertThat(state.data?.contentKey).isEqualTo("one")
+
+        viewModel.onEvent(GeneralSettingsEvent.Load("two"))
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        state = viewModel.uiState.value
+        assertThat(state.data?.contentKey).isEqualTo("two")
+    }
+
+    @Test
+    fun `errors cleared after successful load`() = runTest(dispatcherExtension.testDispatcher) {
+        val viewModel = GeneralSettingsViewModel()
+        viewModel.onEvent(GeneralSettingsEvent.Load(""))
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        var state = viewModel.uiState.value
+        assertThat(state.errors).isNotEmpty()
+
+        viewModel.onEvent(GeneralSettingsEvent.Load("valid"))
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
+        assertThat(state.errors).isEmpty()
+    }
 }


### PR DESCRIPTION
## Summary
- extend SettingsViewModel tests for sequential loads, error recovery and partial configs
- cover additional status codes and scenarios in IssueReporterViewModel tests
- verify headers and error handling in IssueReporterRepository tests
- add repeated load and error recovery cases to GeneralSettingsViewModel tests

## Testing
- `./gradlew :apptoolkit:test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868dc826614832d83651856375546b4