### PR TITLE
Add additional intent and ad manager tests

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestIntentsHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestIntentsHelper.kt
@@ -2,10 +2,17 @@ package com.d4rk.android.libs.apptoolkit.core.utils.helpers
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.res.Resources
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.slot
+import io.mockk.verify
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -58,5 +65,100 @@ class TestIntentsHelper {
         assertFailsWith<RuntimeException> {
             IntentsHelper.openActivity(context, String::class.java)
         }
+    }
+
+    @Test
+    fun `openAppNotificationSettings builds correct intent`() {
+        val context = mockk<Context>()
+        every { context.packageName } returns "pkg"
+        val slot = slot<Intent>()
+        justRun { context.startActivity(capture(slot)) }
+
+        IntentsHelper.openAppNotificationSettings(context)
+
+        val intent = slot.captured
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            assertEquals(Settings.ACTION_APP_NOTIFICATION_SETTINGS, intent.action)
+            assertEquals("pkg", intent.getStringExtra(Settings.EXTRA_APP_PACKAGE))
+        } else {
+            assertEquals("android.settings.APPLICATION_DETAILS_SETTINGS", intent.action)
+            assertEquals(Uri.fromParts("package", "pkg", null), intent.data)
+        }
+    }
+
+    @Test
+    fun `openPlayStoreForApp uses market when resolvable`() {
+        val context = mockk<Context>()
+        val pm = mockk<PackageManager>()
+        every { context.packageManager } returns pm
+        val slot = slot<Intent>()
+        justRun { context.startActivity(capture(slot)) }
+
+        mockkConstructor(Intent::class)
+        every { anyConstructed<Intent>().resolveActivity(pm) } returns mockk()
+
+        IntentsHelper.openPlayStoreForApp(context, "com.test")
+
+        val intent = slot.captured
+        assertEquals(Intent.ACTION_VIEW, intent.action)
+        assertEquals("${AppLinks.MARKET_APP_PAGE}com.test", intent.data.toString())
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+
+    @Test
+    fun `openPlayStoreForApp falls back to web when market missing`() {
+        val context = mockk<Context>()
+        val pm = mockk<PackageManager>()
+        every { context.packageManager } returns pm
+        val slot = slot<Intent>()
+        justRun { context.startActivity(capture(slot)) }
+
+        mockkConstructor(Intent::class)
+        every { anyConstructed<Intent>().resolveActivity(pm) } returns null
+
+        IntentsHelper.openPlayStoreForApp(context, "com.test")
+
+        val intent = slot.captured
+        assertEquals(Intent.ACTION_VIEW, intent.action)
+        assertEquals("${AppLinks.PLAY_STORE_APP}com.test", intent.data.toString())
+    }
+
+    @Test
+    fun `shareApp builds chooser intent`() {
+        val context = mockk<Context>()
+        val res = mockk<Resources>()
+        every { context.resources } returns res
+        every { res.getText(R.string.send_email_using) } returns "send"
+        every { context.getString(R.string.summary_share_message, any()) } returns "msg"
+        val slot = slot<Intent>()
+        justRun { context.startActivity(capture(slot)) }
+
+        IntentsHelper.shareApp(context, R.string.summary_share_message)
+
+        val chooser = slot.captured
+        assertEquals(Intent.ACTION_CHOOSER, chooser.action)
+        val sendIntent = chooser.getParcelableExtra<Intent>(Intent.EXTRA_INTENT)
+        assertEquals(Intent.ACTION_SEND, sendIntent?.action)
+        assertEquals("msg", sendIntent?.getStringExtra(Intent.EXTRA_TEXT))
+        assertEquals("text/plain", sendIntent?.type)
+    }
+
+    @Test
+    fun `sendEmailToDeveloper builds mailto chooser`() {
+        val context = mockk<Context>()
+        every { context.getString(R.string.feedback_for, "App") } returns "subject"
+        every { context.getString(R.string.dear_developer) } returns "body"
+        every { context.getString(R.string.send_email_using) } returns "send"
+        val slot = slot<Intent>()
+        justRun { context.startActivity(capture(slot)) }
+
+        IntentsHelper.sendEmailToDeveloper(context, R.string.app_name)
+
+        val chooser = slot.captured
+        assertEquals(Intent.ACTION_CHOOSER, chooser.action)
+        val inner = chooser.getParcelableExtra<Intent>(Intent.EXTRA_INTENT)
+        assertEquals(Intent.ACTION_SENDTO, inner?.action)
+        assertTrue(inner?.data.toString().startsWith("mailto:"))
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/data/core/ads/TestAdsCoreManager.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/data/core/ads/TestAdsCoreManager.kt
@@ -2,12 +2,23 @@ import android.app.Activity
 import android.content.Context
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import com.google.android.gms.ads.AdError
+import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.MobileAds
+import com.google.android.gms.ads.appopen.AppOpenAd
+import com.google.android.gms.ads.FullScreenContentCallback
 import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import com.d4rk.android.libs.apptoolkit.core.utils.interfaces.OnShowAdCompleteListener
+import org.junit.Assert.assertFalse
 import org.junit.Test
+import java.util.Date
 
 class TestAdsCoreManager {
     @Test
@@ -32,4 +43,120 @@ class TestAdsCoreManager {
 
         manager.showAdIfAvailable(activity)
     }
+
+    @Test
+    fun `loadAd does not load when already loading or available`() {
+        val context = mockk<Context>()
+        val provider = mockk<BuildInfoProvider>()
+        val manager = AdsCoreManager(context, provider)
+        manager.initializeAds("unit")
+
+        val mgrField = AdsCoreManager::class.java.getDeclaredField("appOpenAdManager")
+        mgrField.isAccessible = true
+        val inner = mgrField.get(manager)!!
+
+        val loadingField = inner.javaClass.getDeclaredField("isLoadingAd")
+        loadingField.isAccessible = true
+        loadingField.setBoolean(inner, true)
+
+        mockkStatic(AppOpenAd::class)
+        inner.javaClass.getDeclaredMethod("loadAd", Context::class.java).apply {
+            isAccessible = true
+            invoke(inner, context)
+        }
+        verify(exactly = 0) { AppOpenAd.load(any(), any(), any(), any()) }
+
+        loadingField.setBoolean(inner, false)
+        val adField = inner.javaClass.getDeclaredField("appOpenAd")
+        adField.isAccessible = true
+        adField.set(inner, mockk<AppOpenAd>())
+        val timeField = inner.javaClass.getDeclaredField("loadTime")
+        timeField.isAccessible = true
+        timeField.setLong(inner, Date().time)
+
+        inner.javaClass.getDeclaredMethod("loadAd", Context::class.java).apply {
+            isAccessible = true
+            invoke(inner, context)
+        }
+        verify(exactly = 0) { AppOpenAd.load(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `showAdIfAvailable loads when no ad`() {
+        val context = mockk<Context>()
+        val provider = mockk<BuildInfoProvider>()
+        val manager = AdsCoreManager(context, provider)
+        manager.initializeAds("unit")
+
+        val dataStore = mockk<CommonDataStore>()
+        every { dataStore.ads(any()) } returns flowOf(true)
+        val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
+        storeField.isAccessible = true
+        storeField.set(manager, dataStore)
+
+        mockkStatic(AppOpenAd::class)
+        justRun { AppOpenAd.load(any(), any(), any(), any()) }
+
+        var completed = false
+        val mgrField2 = AdsCoreManager::class.java.getDeclaredField("appOpenAdManager")
+        mgrField2.isAccessible = true
+        val inner2 = mgrField2.get(manager)!!
+        val method = inner2.javaClass.getDeclaredMethod(
+            "showAdIfAvailable",
+            Activity::class.java,
+            OnShowAdCompleteListener::class.java
+        )
+        method.isAccessible = true
+        val listener = object : OnShowAdCompleteListener { override fun onShowAdComplete() { completed = true } }
+        method.invoke(inner2, mockk<Activity>(), listener)
+
+        assert(completed)
+        verify { AppOpenAd.load(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `callback dismiss reloads ad`() {
+        val context = mockk<Context>(relaxed = true)
+        val provider = mockk<BuildInfoProvider>()
+        val manager = AdsCoreManager(context, provider)
+        manager.initializeAds("unit")
+
+        val dataStore = mockk<CommonDataStore>()
+        every { dataStore.ads(any()) } returns flowOf(true)
+        val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
+        storeField.isAccessible = true
+        storeField.set(manager, dataStore)
+
+        val ad = mockk<AppOpenAd>(relaxed = true)
+        val mgrField3 = AdsCoreManager::class.java.getDeclaredField("appOpenAdManager")
+        mgrField3.isAccessible = true
+        val inner3 = mgrField3.get(manager)!!
+        val adField = inner3.javaClass.getDeclaredField("appOpenAd")
+        adField.isAccessible = true
+        adField.set(inner3, ad)
+
+        mockkStatic(AppOpenAd::class)
+        justRun { AppOpenAd.load(any(), any(), any(), any()) }
+
+        val slot = slot<FullScreenContentCallback>()
+        every { ad.fullScreenContentCallback = capture(slot) } returns Unit
+
+        val method2 = inner3.javaClass.getDeclaredMethod(
+            "showAdIfAvailable",
+            Activity::class.java,
+            OnShowAdCompleteListener::class.java
+        )
+        method2.isAccessible = true
+        method2.invoke(inner3, mockk<Activity>(), object : OnShowAdCompleteListener {
+            override fun onShowAdComplete() {}
+        })
+
+        slot.captured.onAdDismissedFullScreenContent()
+
+        val showField = inner3.javaClass.getDeclaredField("isShowingAd")
+        showField.isAccessible = true
+        assertFalse(showField.getBoolean(inner3))
+        verify { AppOpenAd.load(any(), any(), any(), any()) }
+    }
+
 }


### PR DESCRIPTION
## Summary
- expand IntentHelper tests to cover notification settings, Play Store, sharing, and email
- extend AdsCoreManager tests for load conditions and callbacks

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68693150d830832d95edf3165bb2074d