### PR TITLE
Fix BillingRepository initialization

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
@@ -7,6 +7,10 @@ import android.os.Bundle
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.d4rk.android.libs.apptoolkit.app.support.billing.BillingRepository
+import org.koin.android.ext.android.inject
 import com.d4rk.android.apps.apptoolkit.core.di.initializeKoin
 import com.d4rk.android.apps.apptoolkit.core.utils.constants.ads.AdsConstants
 import com.d4rk.android.libs.apptoolkit.data.core.BaseCoreManager
@@ -16,10 +20,11 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.supervisorScope
 import org.koin.android.ext.android.getKoin
 
-class AppToolkit : BaseCoreManager() {
+class AppToolkit : BaseCoreManager(), DefaultLifecycleObserver {
     private var currentActivity : Activity? = null
 
     private val adsCoreManager : AdsCoreManager by lazy { getKoin().get<AdsCoreManager>() }
+    private val billingRepository: BillingRepository by inject()
 
     override fun onCreate() {
         initializeKoin(context = this)
@@ -39,6 +44,10 @@ class AppToolkit : BaseCoreManager() {
     @OnLifecycleEvent(Lifecycle.Event.ON_START)
     fun onMoveToForeground() {
         currentActivity?.let { adsCoreManager.showAdIfAvailable(it) }
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+        billingRepository.processPastPurchases()
     }
 
     override fun onActivityCreated(activity : Activity , savedInstanceState : Bundle?) {}

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -16,7 +16,7 @@ import org.koin.dsl.module
 val appToolkitModule : Module = module {
     single<StartupProvider> { AppStartupProvider() }
 
-    single { BillingRepository.getInstance(context = get()) }
+    single(createdAtStart = true) { BillingRepository.getInstance(context = get()) }
     viewModel {
         SupportViewModel(billingRepository = get(), dispatcherProvider = get())
     }


### PR DESCRIPTION
## Summary
- eagerly initialize BillingRepository with Koin
- inject BillingRepository in AppToolkit Application class
- process past purchases whenever the app resumes

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a295b4824832d8f3475ec0a8ff723