### PR TITLE
Add additional ViewModel and ads tests

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -173,4 +173,24 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
         setup(fetchFlow = flow, initialFavorites = setOf("pkg"), testDispatcher = dispatcherExtension.testDispatcher)
         viewModel.uiState.testSuccess(expectedSize = 2, testDispatcher = dispatcherExtension.testDispatcher)
     }
+
+    @Test
+    fun `toggle favorite throws after load`() = runTest(dispatcherExtension.testDispatcher) {
+        val apps = listOf(AppInfo("App", "pkg", "url"))
+        val flow = flow {
+            emit(DataState.Loading<List<AppInfo>, Error>())
+            emit(DataState.Success<List<AppInfo>, Error>(apps))
+        }
+        setup(
+            fetchFlow = flow,
+            initialFavorites = emptySet(),
+            testDispatcher = dispatcherExtension.testDispatcher,
+            toggleError = RuntimeException("fail")
+        )
+
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        viewModel.toggleFavorite("pkg")
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        assertThat(viewModel.favorites.value.contains("pkg")).isFalse()
+    }
 }


### PR DESCRIPTION
## Summary
- expand `TestAdsCoreManager` coverage
- cover `MainViewModel` exception path and drawer reload
- cover `AppsListViewModel` error flows
- cover `FavoriteAppsViewModel` failing toggle case

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b7e3dee5c832d910bd6d124bfadea