### PR TITLE
Add concurrency test for AboutViewModel

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
@@ -96,4 +96,20 @@ class TestAboutViewModel {
 
         assertThat(second.timeStamp).isGreaterThan(firstTimestamp)
     }
+
+    @Test
+    fun `rapid successive copy events keep snackbar visible`() = runTest(dispatcherExtension.testDispatcher) {
+        val dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
+        val viewModel = AboutViewModel(dispatcherProvider)
+
+        repeat(5) {
+            viewModel.onEvent(AboutEvents.CopyDeviceInfo)
+        }
+
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.snackbar).isNotNull()
+        assertThat(state.data?.showDeviceInfoCopiedSnackbar).isTrue()
+    }
 }


### PR DESCRIPTION
## Summary
- ensure the snackbar state remains consistent when `CopyDeviceInfo` is fired several times in quick succession

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf0edbf84832dac215346b8eb42ee