### PR TITLE
Add callback failure test for ClipboardHelper

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestClipboardHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestClipboardHelper.kt
@@ -100,4 +100,26 @@ class TestClipboardHelper {
             assertTrue(executed)
         }
     }
+
+    @Test
+    fun `copyTextToClipboard propagates exception from callback`() {
+        val manager = mockk<ClipboardManager>()
+        val context = mockk<Context>()
+        every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns manager
+        justRun { manager.setPrimaryClip(any()) }
+
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+            assertFailsWith<RuntimeException> {
+                ClipboardHelper.copyTextToClipboard(context, "l", "t") {
+                    throw RuntimeException("callback failed")
+                }
+            }
+        } else {
+            ClipboardHelper.copyTextToClipboard(context, "l", "t") {
+                throw RuntimeException("callback failed")
+            }
+        }
+
+        verify { manager.setPrimaryClip(any()) }
+    }
 }


### PR DESCRIPTION
## Summary
- cover callback exception propagation path in `ClipboardHelper`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf12afec4832dacddcaae6c6d3bcd