### PR TITLE
Add missing view model tests

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -34,7 +34,8 @@ open class TestAppsListViewModelBase {
         initialFavorites: Set<String> = emptySet(),
         testDispatcher: TestDispatcher,
         favoritesFlow: Flow<Set<String>>? = null,
-        toggleError: Throwable? = null
+        toggleError: Throwable? = null,
+        fetchThrows: Throwable? = null
     ) {
         println("\uD83E\uDDEA [SETUP] Initial favorites: $initialFavorites")
         dispatcherProvider = TestDispatchers(testDispatcher)
@@ -58,7 +59,11 @@ open class TestAppsListViewModelBase {
         } else {
             coEvery { dataStore.toggleFavoriteApp(any()) } returns Unit
         }
-        coEvery { fetchUseCase.invoke() } returns fetchFlow
+        if (fetchThrows != null) {
+            coEvery { fetchUseCase.invoke() } throws fetchThrows
+        } else {
+            coEvery { fetchUseCase.invoke() } returns fetchFlow
+        }
 
         viewModel = AppsListViewModel(fetchUseCase, dispatcherProvider, dataStore)
         println("\u2705 [SETUP] ViewModel initialized")


### PR DESCRIPTION
## Summary
- handle throwable `FetchDeveloperAppsUseCase` in tests
- test incremental loading, favorites updates, and thrown exception

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d88d7f6d0832d8ca6952c3a236846