### PR TITLE
Add verbose logging across unit tests

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -27,6 +27,7 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
 
     @Test
     fun `load favorites - success`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] load favorites - success")
         val apps = listOf(AppInfo("App1", "pkg1", "url1"), AppInfo("App2", "pkg2", "url2"))
         val flow = flow {
             emit(DataState.Loading<List<AppInfo>, Error>())
@@ -34,10 +35,12 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
         }
         setup(fetchFlow = flow, initialFavorites = setOf("pkg1"), testDispatcher = dispatcherExtension.testDispatcher)
         viewModel.uiState.testSuccess(expectedSize = 1, testDispatcher = dispatcherExtension.testDispatcher)
+        println("\uD83C\uDFC1 [TEST DONE] load favorites - success")
     }
 
     @Test
     fun `load favorites - empty`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] load favorites - empty")
         val apps = listOf(AppInfo("App1", "pkg1", "url1"))
         val flow = flow {
             emit(DataState.Loading<List<AppInfo>, Error>())
@@ -45,20 +48,24 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
         }
         setup(fetchFlow = flow, initialFavorites = emptySet(), testDispatcher = dispatcherExtension.testDispatcher)
         viewModel.uiState.testEmpty(testDispatcher = dispatcherExtension.testDispatcher)
+        println("\uD83C\uDFC1 [TEST DONE] load favorites - empty")
     }
 
     @Test
     fun `load favorites - error`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] load favorites - error")
         val flow = flow {
             emit(DataState.Loading<List<AppInfo>, Error>())
             emit(DataState.Error<List<AppInfo>, Error>(error = object : Error {}))
         }
         setup(fetchFlow = flow, initialFavorites = emptySet(), testDispatcher = dispatcherExtension.testDispatcher)
         viewModel.uiState.testError(testDispatcher = dispatcherExtension.testDispatcher)
+        println("\uD83C\uDFC1 [TEST DONE] load favorites - error")
     }
 
     @Test
     fun `toggle favorite`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] toggle favorite")
         val apps = listOf(AppInfo("App", "pkg", "url"))
         val flow = flow {
             emit(DataState.Success<List<AppInfo>, Error>(apps))
@@ -66,10 +73,12 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
         setup(fetchFlow = flow, initialFavorites = setOf("pkg"), testDispatcher = dispatcherExtension.testDispatcher)
         toggleAndAssert(packageName = "pkg", expected = false, testDispatcher = dispatcherExtension.testDispatcher)
         toggleAndAssert(packageName = "pkg", expected = true, testDispatcher = dispatcherExtension.testDispatcher)
+        println("\uD83C\uDFC1 [TEST DONE] toggle favorite")
     }
 
     @Test
     fun `mismatched favorites filtered`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] mismatched favorites filtered")
         val apps = listOf(AppInfo("App1", "pkg1", "url1"), AppInfo("App2", "pkg2", "url2"))
         val flow = flow {
             emit(DataState.Loading<List<AppInfo>, Error>())
@@ -77,11 +86,13 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
         }
         setup(fetchFlow = flow, initialFavorites = setOf("pkg1", "pkg2", "pkg3"), testDispatcher = dispatcherExtension.testDispatcher)
         viewModel.uiState.testSuccess(expectedSize = 2, testDispatcher = dispatcherExtension.testDispatcher)
+        println("\uD83C\uDFC1 [TEST DONE] mismatched favorites filtered")
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `favorites change during loading`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] favorites change during loading")
         val apps = listOf(AppInfo("App", "pkg", "url"))
         val flow = flow {
             emit(DataState.Loading<List<AppInfo>, Error>())
@@ -94,10 +105,12 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         assertTrue(viewModel.uiState.value.screenState is ScreenState.Success)
         assertThat(viewModel.uiState.value.data?.apps?.size).isEqualTo(1)
+        println("\uD83C\uDFC1 [TEST DONE] favorites change during loading")
     }
 
     @Test
     fun `state recovers after reload`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] state recovers after reload")
         val shared = MutableSharedFlow<DataState<List<AppInfo>, Error>>()
         setup(fetchFlow = shared, initialFavorites = setOf("pkg"), testDispatcher = dispatcherExtension.testDispatcher)
 
@@ -114,10 +127,12 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
 
         assertTrue(viewModel.uiState.value.screenState is ScreenState.Success)
         assertThat(viewModel.uiState.value.data?.apps?.size).isEqualTo(1)
+        println("\uD83C\uDFC1 [TEST DONE] state recovers after reload")
     }
 
     @Test
     fun `datastore flow error leaves loading state`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] datastore flow error leaves loading state")
         val apps = listOf(AppInfo("App", "pkg", "url"))
         val fetchFlow = flow {
             emit(DataState.Loading<List<AppInfo>, Error>())
@@ -133,10 +148,12 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
             expectNoEvents()
             assertTrue(viewModel.uiState.value.screenState is ScreenState.IsLoading)
         }
+        println("\uD83C\uDFC1 [TEST DONE] datastore flow error leaves loading state")
     }
 
     @Test
     fun `toggle favorite after removal`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] toggle favorite after removal")
         val shared = MutableSharedFlow<DataState<List<AppInfo>, Error>>()
         val favorites = MutableSharedFlow<Set<String>>(replay = 1).apply { tryEmit(setOf("pkg")) }
         setup(fetchFlow = shared, testDispatcher = dispatcherExtension.testDispatcher, favoritesFlow = favorites)
@@ -158,10 +175,12 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
         viewModel.toggleFavorite("pkg")
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         assertThat(viewModel.favorites.value.contains("pkg")).isFalse()
+        println("\uD83C\uDFC1 [TEST DONE] toggle favorite after removal")
     }
 
     @Test
     fun `duplicate apps kept in favorites list`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] duplicate apps kept in favorites list")
         val apps = listOf(
             AppInfo("App", "pkg", "url"),
             AppInfo("App", "pkg", "url")
@@ -172,10 +191,12 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
         }
         setup(fetchFlow = flow, initialFavorites = setOf("pkg"), testDispatcher = dispatcherExtension.testDispatcher)
         viewModel.uiState.testSuccess(expectedSize = 2, testDispatcher = dispatcherExtension.testDispatcher)
+        println("\uD83C\uDFC1 [TEST DONE] duplicate apps kept in favorites list")
     }
 
     @Test
     fun `toggle favorite throws after load`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] toggle favorite throws after load")
         val apps = listOf(AppInfo("App", "pkg", "url"))
         val flow = flow {
             emit(DataState.Loading<List<AppInfo>, Error>())
@@ -192,5 +213,6 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
         viewModel.toggleFavorite("pkg")
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         assertThat(viewModel.favorites.value.contains("pkg")).isFalse()
+        println("\uD83C\uDFC1 [TEST DONE] toggle favorite throws after load")
     }
 }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/TestMainViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/TestMainViewModel.kt
@@ -36,23 +36,28 @@ class TestMainViewModel {
     private lateinit var updateUseCase: PerformInAppUpdateUseCase
 
     private fun setup(flow: Flow<DataState<Int, Errors>>, dispatcher: TestDispatcher) {
+        println("\uD83E\uDDEA [SETUP] Starting setup")
         dispatcherProvider = TestDispatchers(dispatcher)
         updateUseCase = mockk()
         coEvery { updateUseCase.invoke(Unit) } returns flow
         viewModel = MainViewModel(updateUseCase, dispatcherProvider)
+        println("\u2705 [SETUP] ViewModel initialized")
     }
 
     @Test
     fun `navigation items loaded on init`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] navigation items loaded on init")
         val flow = flow<DataState<Int, Errors>> { }
         setup(flow, dispatcherExtension.testDispatcher)
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val items = viewModel.uiState.value.data?.navigationDrawerItems
         assertThat(items?.size).isEqualTo(4)
+        println("\uD83C\uDFC1 [TEST DONE] navigation items loaded on init")
     }
 
     @Test
     fun `check update error shows snackbar`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] check update error shows snackbar")
         val flow = flow {
             emit(DataState.Error<Int, Errors>(error = Errors.UseCase.FAILED_TO_UPDATE_APP))
         }
@@ -63,10 +68,12 @@ class TestMainViewModel {
         assertThat(snackbar).isNotNull()
         val msg = snackbar!!.message as UiTextHelper.StringResource
         assertThat(msg.resourceId).isEqualTo(R.string.snack_update_failed)
+        println("\uD83C\uDFC1 [TEST DONE] check update error shows snackbar")
     }
 
     @Test
     fun `check update success`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] check update success")
         val flow = flow {
             emit(DataState.Success<Int, Errors>(0))
         }
@@ -75,20 +82,24 @@ class TestMainViewModel {
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val snackbar = viewModel.uiState.value.snackbar
         assertThat(snackbar).isNull()
+        println("\uD83C\uDFC1 [TEST DONE] check update success")
     }
 
     @Test
     fun `load navigation via event`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] load navigation via event")
         val flow = flow<DataState<Int, Errors>> { }
         setup(flow, dispatcherExtension.testDispatcher)
         viewModel.onEvent(MainEvent.LoadNavigation)
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val items = viewModel.uiState.value.data?.navigationDrawerItems
         assertThat(items?.size).isEqualTo(4)
+        println("\uD83C\uDFC1 [TEST DONE] load navigation via event")
     }
 
     @Test
     fun `dismiss snackbar clears state`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] dismiss snackbar clears state")
         val flow = flow {
             emit(DataState.Error<Int, Errors>(error = Errors.UseCase.FAILED_TO_UPDATE_APP))
         }
@@ -100,10 +111,12 @@ class TestMainViewModel {
         viewModel.screenState.dismissSnackbar()
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         assertThat(viewModel.uiState.value.snackbar).isNull()
+        println("\uD83C\uDFC1 [TEST DONE] dismiss snackbar clears state")
     }
 
     @Test
     fun `multiple update attempts error then success`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] multiple update attempts error then success")
         val errorFlow = flow {
             emit(DataState.Loading())
             emit(DataState.Error<Int, Errors>(error = Errors.Network.REQUEST_TIMEOUT))
@@ -123,10 +136,12 @@ class TestMainViewModel {
         viewModel.onEvent(MainEvent.CheckForUpdates)
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         assertThat(viewModel.uiState.value.snackbar).isNull()
+        println("\uD83C\uDFC1 [TEST DONE] multiple update attempts error then success")
     }
 
     @Test
     fun `handle different update errors`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] handle different update errors")
         val timeoutFlow = flow {
             emit(DataState.Error<Int, Errors>(error = Errors.Network.REQUEST_TIMEOUT))
         }
@@ -143,10 +158,12 @@ class TestMainViewModel {
         viewModel.onEvent(MainEvent.CheckForUpdates)
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         assertThat(viewModel.uiState.value.snackbar).isNotNull()
+        println("\uD83C\uDFC1 [TEST DONE] handle different update errors")
     }
 
     @Test
     fun `repeated navigation event does not duplicate items`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] repeated navigation event does not duplicate items")
         val flow = flow<DataState<Int, Errors>> { }
         setup(flow, dispatcherExtension.testDispatcher)
         viewModel.onEvent(MainEvent.LoadNavigation)
@@ -159,10 +176,12 @@ class TestMainViewModel {
 
         assertThat(firstItems?.size).isEqualTo(4)
         assertThat(secondItems?.size).isEqualTo(4)
+        println("\uD83C\uDFC1 [TEST DONE] repeated navigation event does not duplicate items")
     }
 
     @Test
     fun `loading update emits nothing else`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] loading update emits nothing else")
         val flow = flow {
             emit(DataState.Loading<Int, Errors>())
         }
@@ -170,10 +189,12 @@ class TestMainViewModel {
         viewModel.onEvent(MainEvent.CheckForUpdates)
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         assertThat(viewModel.uiState.value.snackbar).isNull()
+        println("\uD83C\uDFC1 [TEST DONE] loading update emits nothing else")
     }
 
     @Test
     fun `unexpected update result is ignored`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] unexpected update result is ignored")
         val flow = flow {
             emit(DataState.Success<Int, Errors>(5))
         }
@@ -181,10 +202,12 @@ class TestMainViewModel {
         viewModel.onEvent(MainEvent.CheckForUpdates)
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         assertThat(viewModel.uiState.value.snackbar).isNull()
+        println("\uD83C\uDFC1 [TEST DONE] unexpected update result is ignored")
     }
 
     @Test
     fun `use case throws propagates exception`() {
+        println("\uD83D\uDE80 [TEST] use case throws propagates exception")
         assertFailsWith<RuntimeException> {
             runTest(dispatcherExtension.testDispatcher) {
                 val flow = flow<DataState<Int, Errors>> { }
@@ -195,10 +218,12 @@ class TestMainViewModel {
                 dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
             }
         }
+        println("\uD83C\uDFC1 [TEST DONE] use case throws propagates exception")
     }
 
     @Test
     fun `flow throwing propagates exception`() {
+        println("\uD83D\uDE80 [TEST] flow throwing propagates exception")
         assertFailsWith<RuntimeException> {
             runTest(dispatcherExtension.testDispatcher) {
                 val flow = flow<DataState<Int, Errors>> {
@@ -210,10 +235,12 @@ class TestMainViewModel {
                 dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
             }
         }
+        println("\uD83C\uDFC1 [TEST DONE] flow throwing propagates exception")
     }
 
     @Test
     fun `navigation items persist after rotation`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] navigation items persist after rotation")
         val flow = flow<DataState<Int, Errors>> { }
         setup(flow, dispatcherExtension.testDispatcher)
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -225,10 +252,12 @@ class TestMainViewModel {
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val secondItems = viewModel.uiState.value.data?.navigationDrawerItems
         assertThat(secondItems?.size).isEqualTo(4)
+        println("\uD83C\uDFC1 [TEST DONE] navigation items persist after rotation")
     }
 
     @Test
     fun `concurrent CheckForUpdates events`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] concurrent CheckForUpdates events")
         val flow = flow {
             emit(DataState.Error<Int, Errors>(error = Errors.UseCase.FAILED_TO_UPDATE_APP))
         }
@@ -240,10 +269,12 @@ class TestMainViewModel {
         assertThat(snackbar).isNotNull()
         val msg = snackbar!!.message as UiTextHelper.StringResource
         assertThat(msg.resourceId).isEqualTo(R.string.snack_update_failed)
+        println("\uD83C\uDFC1 [TEST DONE] concurrent CheckForUpdates events")
     }
 
     @Test
     fun `load navigation replaces invalid config`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] load navigation replaces invalid config")
         val flow = flow<DataState<Int, Errors>> { }
         setup(flow, dispatcherExtension.testDispatcher)
         viewModel.screenState.updateData(ScreenState.Success()) { it.copy(navigationDrawerItems = emptyList()) }
@@ -252,5 +283,6 @@ class TestMainViewModel {
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val items = viewModel.uiState.value.data?.navigationDrawerItems
         assertThat(items?.size).isEqualTo(4)
+        println("\uD83C\uDFC1 [TEST DONE] load navigation replaces invalid config")
     }
 }


### PR DESCRIPTION
## Summary
- add setup and assertion logging in FavoriteAppsViewModelBase
- log test states in FavoriteAppsViewModel tests
- log test states in MainViewModel tests

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e2d05e974832dbfe3ac668d9e6ffa