### PR TITLE
Add println statements to all unit tests

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
@@ -22,6 +22,7 @@ class TestAboutViewModel {
 
     @Test
     fun `copy device info shows snackbar`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] copy device info shows snackbar")
         val dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
         val viewModel = AboutViewModel(dispatcherProvider)
         viewModel.onEvent(AboutEvents.CopyDeviceInfo)
@@ -31,10 +32,12 @@ class TestAboutViewModel {
         val snackbar = state.snackbar!!
         val msg = snackbar.message as UiTextHelper.StringResource
         assertThat(msg.resourceId).isEqualTo(R.string.snack_device_info_copied)
+        println("🏁 [TEST DONE] copy device info shows snackbar")
     }
 
     @Test
     fun `dismiss snackbar resets state`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] dismiss snackbar resets state")
         val dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
         val viewModel = AboutViewModel(dispatcherProvider)
 
@@ -48,10 +51,12 @@ class TestAboutViewModel {
         val state = viewModel.uiState.value
         assertThat(state.snackbar).isNull()
         assertThat(state.data?.showDeviceInfoCopiedSnackbar).isFalse()
+        println("🏁 [TEST DONE] dismiss snackbar resets state")
     }
 
     @Test
     fun `snackbar can be shown again after dismissal`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] snackbar can be shown again after dismissal")
         val dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
         val viewModel = AboutViewModel(dispatcherProvider)
 
@@ -80,10 +85,12 @@ class TestAboutViewModel {
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         assertThat(viewModel.uiState.value.snackbar).isNull()
         assertThat(viewModel.uiState.value.data?.showDeviceInfoCopiedSnackbar).isFalse()
+        println("🏁 [TEST DONE] snackbar can be shown again after dismissal")
     }
 
     @Test
     fun `repeated copy events show snackbar each time`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] repeated copy events show snackbar each time")
         val dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
         val viewModel = AboutViewModel(dispatcherProvider)
 
@@ -97,10 +104,12 @@ class TestAboutViewModel {
         val second = viewModel.uiState.value.snackbar!!
 
         assertThat(second.timeStamp).isGreaterThan(firstTimestamp)
+        println("🏁 [TEST DONE] repeated copy events show snackbar each time")
     }
 
     @Test
     fun `rapid successive copy events keep snackbar visible`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] rapid successive copy events keep snackbar visible")
         val dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
         val viewModel = AboutViewModel(dispatcherProvider)
 
@@ -113,10 +122,12 @@ class TestAboutViewModel {
         val state = viewModel.uiState.value
         assertThat(state.snackbar).isNotNull()
         assertThat(state.data?.showDeviceInfoCopiedSnackbar).isTrue()
+        println("🏁 [TEST DONE] rapid successive copy events keep snackbar visible")
     }
 
     @Test
     fun `changing screen data resets copy state`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] changing screen data resets copy state")
         val dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
         val viewModel = AboutViewModel(dispatcherProvider)
 
@@ -131,10 +142,12 @@ class TestAboutViewModel {
         val state = viewModel.uiState.value
         assertThat(state.data?.showDeviceInfoCopiedSnackbar).isFalse()
         assertThat(state.snackbar).isNotNull()
+        println("🏁 [TEST DONE] changing screen data resets copy state")
     }
 
     @Test
     fun `new viewmodel has default state`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] new viewmodel has default state")
         val dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
         val viewModel = AboutViewModel(dispatcherProvider)
 
@@ -146,5 +159,6 @@ class TestAboutViewModel {
         val state = recreated.uiState.value
         assertThat(state.snackbar).isNull()
         assertThat(state.data?.showDeviceInfoCopiedSnackbar).isFalse()
+        println("🏁 [TEST DONE] new viewmodel has default state")
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/utils/TestCleanHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/utils/TestCleanHelper.kt
@@ -16,6 +16,7 @@ class TestCleanHelper {
 
     @Test
     fun `clearApplicationCache deletes cache directories`() {
+        println("🚀 [TEST] clearApplicationCache deletes cache directories")
         val dir1 = createTempDirectory().toFile()
         val dir2 = createTempDirectory().toFile()
         val dir3 = createTempDirectory().toFile()
@@ -37,10 +38,12 @@ class TestCleanHelper {
         assertFalse(dir3.exists())
         verify { context.getString(R.string.cache_cleared_success) }
         verify { Toast.makeText(context, "success", Toast.LENGTH_SHORT) }
+        println("🏁 [TEST DONE] clearApplicationCache deletes cache directories")
     }
 
     @Test
     fun `clearApplicationCache shows error toast when deletion fails`() {
+        println("🚀 [TEST] clearApplicationCache shows error toast when deletion fails")
         val dir1 = createTempDirectory().toFile()
         val failing = mockk<java.io.File>()
         every { failing.deleteRecursively() } returns false
@@ -64,20 +67,24 @@ class TestCleanHelper {
         verify { failing.deleteRecursively() }
         verify { context.getString(R.string.cache_cleared_error) }
         verify { Toast.makeText(context, "error", Toast.LENGTH_SHORT) }
+        println("🏁 [TEST DONE] clearApplicationCache shows error toast when deletion fails")
     }
 
     @Test
     fun `clearApplicationCache throws when directory inaccessible`() {
+        println("🚀 [TEST] clearApplicationCache throws when directory inaccessible")
         val context = mockk<Context>()
         every { context.cacheDir } throws SecurityException("denied")
 
         assertFailsWith<SecurityException> {
             CleanHelper.clearApplicationCache(context)
         }
+        println("🏁 [TEST DONE] clearApplicationCache throws when directory inaccessible")
     }
 
     @Test
     fun `clearApplicationCache handles missing directories`() {
+        println("🚀 [TEST] clearApplicationCache handles missing directories")
         val dir1 = createTempDirectory().toFile().also { it.deleteRecursively() }
         val dir2 = createTempDirectory().toFile().also { it.deleteRecursively() }
         val dir3 = createTempDirectory().toFile().also { it.deleteRecursively() }
@@ -96,10 +103,12 @@ class TestCleanHelper {
 
         verify { context.getString(R.string.cache_cleared_success) }
         verify { Toast.makeText(context, "success", Toast.LENGTH_SHORT) }
+        println("🏁 [TEST DONE] clearApplicationCache handles missing directories")
     }
 
     @Test
     fun `clearApplicationCache propagates io exception`() {
+        println("🚀 [TEST] clearApplicationCache propagates io exception")
         val dir1 = createTempDirectory().toFile()
         val failing = mockk<java.io.File>()
         every { failing.deleteRecursively() } throws java.io.IOException("io")
@@ -114,10 +123,12 @@ class TestCleanHelper {
         assertFailsWith<java.io.IOException> {
             CleanHelper.clearApplicationCache(context)
         }
+        println("🏁 [TEST DONE] clearApplicationCache propagates io exception")
     }
 
     @Test
     fun `clearApplicationCache propagates toast exception`() {
+        println("🚀 [TEST] clearApplicationCache propagates toast exception")
         val dir1 = createTempDirectory().toFile()
         val dir2 = createTempDirectory().toFile()
         val dir3 = createTempDirectory().toFile()
@@ -134,10 +145,12 @@ class TestCleanHelper {
         assertFailsWith<RuntimeException> {
             CleanHelper.clearApplicationCache(context)
         }
+        println("🏁 [TEST DONE] clearApplicationCache propagates toast exception")
     }
 
     @Test
     fun `clearApplicationCache handles partial deletion`() {
+        println("🚀 [TEST] clearApplicationCache handles partial deletion")
         val dir1 = createTempDirectory().toFile()
         val failing2 = mockk<java.io.File>()
         every { failing2.deleteRecursively() } returns false
@@ -163,5 +176,6 @@ class TestCleanHelper {
         verify { failing3.deleteRecursively() }
         verify { context.getString(R.string.cache_cleared_error) }
         verify { Toast.makeText(context, "error", Toast.LENGTH_SHORT) }
+        println("🏁 [TEST DONE] clearApplicationCache handles partial deletion")
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/TestOnboardingViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/TestOnboardingViewModel.kt
@@ -7,6 +7,7 @@ class TestOnboardingViewModel {
 
     @Test
     fun `current tab index mutates as expected`() {
+        println("🚀 [TEST] current tab index mutates as expected")
         val viewModel = OnboardingViewModel()
 
         // Default value
@@ -27,10 +28,12 @@ class TestOnboardingViewModel {
         // Reset back to default
         viewModel.currentTabIndex = 0
         assertThat(viewModel.currentTabIndex).isEqualTo(0)
+        println("🏁 [TEST DONE] current tab index mutates as expected")
     }
 
     @Test
     fun `repeated index changes remain stable`() {
+        println("🚀 [TEST] repeated index changes remain stable")
         val viewModel = OnboardingViewModel()
 
         repeat(5) { index ->
@@ -41,5 +44,6 @@ class TestOnboardingViewModel {
 
         viewModel.currentTabIndex = 0
         assertThat(viewModel.currentTabIndex).isEqualTo(0)
+        println("🏁 [TEST DONE] repeated index changes remain stable")
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/utils/helpers/TestCrashlyticsOnboardingStateManager.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/utils/helpers/TestCrashlyticsOnboardingStateManager.kt
@@ -8,19 +8,23 @@ class TestCrashlyticsOnboardingStateManager {
 
     @Test
     fun `open and dismiss dialog update state`() {
+        println("🚀 [TEST] open and dismiss dialog update state")
         CrashlyticsOnboardingStateManager.openDialog()
         assertTrue(CrashlyticsOnboardingStateManager.showCrashlyticsDialog)
         CrashlyticsOnboardingStateManager.dismissDialog()
         assertFalse(CrashlyticsOnboardingStateManager.showCrashlyticsDialog)
+        println("🏁 [TEST DONE] open and dismiss dialog update state")
     }
 
     @Test
     fun `repeated open and dismiss calls`() {
+        println("🚀 [TEST] repeated open and dismiss calls")
         CrashlyticsOnboardingStateManager.openDialog()
         CrashlyticsOnboardingStateManager.openDialog()
         assertTrue(CrashlyticsOnboardingStateManager.showCrashlyticsDialog)
         CrashlyticsOnboardingStateManager.dismissDialog()
         CrashlyticsOnboardingStateManager.dismissDialog()
         assertFalse(CrashlyticsOnboardingStateManager.showCrashlyticsDialog)
+        println("🏁 [TEST DONE] repeated open and dismiss calls")
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/TestPermissionsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/TestPermissionsViewModel.kt
@@ -40,6 +40,7 @@ class TestPermissionsViewModel {
 
     @Test
     fun `load permissions success`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load permissions success")
         val config = SettingsConfig(title = "title", categories = listOf(SettingsCategory(title = "c")))
         setup(config, dispatcherExtension.testDispatcher)
         val context = mockk<Context>(relaxed = true)
@@ -48,10 +49,12 @@ class TestPermissionsViewModel {
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.categories?.size).isEqualTo(1)
+        println("🏁 [TEST DONE] load permissions success")
     }
 
     @Test
     fun `load permissions empty`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load permissions empty")
         val config = SettingsConfig(title = "title", categories = emptyList())
         setup(config, dispatcherExtension.testDispatcher)
         val context = mockk<Context>(relaxed = true)
@@ -61,10 +64,12 @@ class TestPermissionsViewModel {
         assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
         val error = state.errors.first().message as UiTextHelper.DynamicString
         assertThat(error.content).isEqualTo("No settings found")
+        println("🏁 [TEST DONE] load permissions empty")
     }
 
     @Test
     fun `load permissions provider throws`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load permissions provider throws")
         dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
         provider = mockk()
         every { provider.providePermissionsConfig(any()) } throws IllegalStateException("boom")
@@ -76,10 +81,12 @@ class TestPermissionsViewModel {
 
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.IsLoading::class.java)
+        println("🏁 [TEST DONE] load permissions provider throws")
     }
 
     @Test
     fun `dismiss errors clears state`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] dismiss errors clears state")
         val config = SettingsConfig(title = "title", categories = emptyList())
         setup(config, dispatcherExtension.testDispatcher)
         val context = mockk<Context>(relaxed = true)
@@ -90,10 +97,12 @@ class TestPermissionsViewModel {
         viewModel.screenState.setErrors(emptyList())
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         assertThat(viewModel.uiState.value.errors).isEmpty()
+        println("🏁 [TEST DONE] dismiss errors clears state")
     }
 
     @Test
     fun `load permissions valid after error`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load permissions valid after error")
         val errorConfig = SettingsConfig(title = "title", categories = emptyList())
         val successConfig = SettingsConfig(title = "title", categories = listOf(SettingsCategory(title = "c")))
         dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
@@ -112,10 +121,12 @@ class TestPermissionsViewModel {
         state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.categories?.size).isEqualTo(1)
+        println("🏁 [TEST DONE] load permissions valid after error")
     }
 
     @Test
     fun `load permissions error after success`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load permissions error after success")
         val successConfig = SettingsConfig(title = "title", categories = listOf(SettingsCategory(title = "c")))
         val errorConfig = SettingsConfig(title = "title", categories = emptyList())
         dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
@@ -133,10 +144,12 @@ class TestPermissionsViewModel {
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
+        println("🏁 [TEST DONE] load permissions error after success")
     }
 
     @Test
     fun `load permissions provider returns null`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load permissions provider returns null")
         dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
         provider = mockk()
         every { provider.providePermissionsConfig(any()) } returns SettingsConfig(title = "null test", categories = emptyList())
@@ -148,10 +161,12 @@ class TestPermissionsViewModel {
 
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
+        println("🏁 [TEST DONE] load permissions provider returns null")
     }
 
     @Test
     fun `concurrent load events yield latest state`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] concurrent load events yield latest state")
         val first = SettingsConfig(title = "first", categories = listOf(SettingsCategory(title = "one")))
         val second = SettingsConfig(title = "second", categories = emptyList())
         dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
@@ -166,10 +181,12 @@ class TestPermissionsViewModel {
 
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
+        println("🏁 [TEST DONE] concurrent load events yield latest state")
     }
 
     @Test
     fun `load permissions with malformed data`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load permissions with malformed data")
         val malformed = SettingsCategory(
             title = "",
             preferences = listOf(SettingsPreference(key = null, title = null))
@@ -184,10 +201,12 @@ class TestPermissionsViewModel {
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.categories?.first()?.preferences?.size).isEqualTo(1)
+        println("🏁 [TEST DONE] load permissions with malformed data")
     }
 
     @Test
     fun `load permissions with duplicated categories`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load permissions with duplicated categories")
         val category = SettingsCategory(title = "dup")
         val config = SettingsConfig(title = "t", categories = listOf(category, category))
         setup(config, dispatcherExtension.testDispatcher)
@@ -199,10 +218,12 @@ class TestPermissionsViewModel {
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.categories?.size).isEqualTo(2)
+        println("🏁 [TEST DONE] load permissions with duplicated categories")
     }
 
     @Test
     fun `load very large permissions config`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load very large permissions config")
         val prefs = List(10) { index -> SettingsPreference(key = "k$index") }
         val categories = List(50) { index -> SettingsCategory(title = "c$index", preferences = prefs) }
         val config = SettingsConfig(title = "big", categories = categories)
@@ -215,5 +236,6 @@ class TestPermissionsViewModel {
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.categories?.size).isEqualTo(50)
+        println("🏁 [TEST DONE] load very large permissions config")
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
@@ -20,16 +20,19 @@ class TestGeneralSettingsViewModel {
 
     @Test
     fun `load content success`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load content success")
         val viewModel = GeneralSettingsViewModel()
         viewModel.onEvent(GeneralSettingsEvent.Load("key"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.contentKey).isEqualTo("key")
+        println("🏁 [TEST DONE] load content success")
     }
 
     @Test
     fun `load content invalid`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load content invalid")
         val viewModel = GeneralSettingsViewModel()
         viewModel.onEvent(GeneralSettingsEvent.Load(null))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -37,10 +40,12 @@ class TestGeneralSettingsViewModel {
         assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
         val error = state.errors.first().message as UiTextHelper.StringResource
         assertThat(error.resourceId).isEqualTo(R.string.error_invalid_content_key)
+        println("🏁 [TEST DONE] load content invalid")
     }
 
     @Test
     fun `load content blank`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load content blank")
         val viewModel = GeneralSettingsViewModel()
         viewModel.onEvent(GeneralSettingsEvent.Load(""))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -48,10 +53,12 @@ class TestGeneralSettingsViewModel {
         assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
         val error = state.errors.first().message as UiTextHelper.StringResource
         assertThat(error.resourceId).isEqualTo(R.string.error_invalid_content_key)
+        println("🏁 [TEST DONE] load content blank")
     }
 
     @Test
     fun `multiple load calls update key`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] multiple load calls update key")
         val viewModel = GeneralSettingsViewModel()
         viewModel.onEvent(GeneralSettingsEvent.Load("one"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -62,10 +69,12 @@ class TestGeneralSettingsViewModel {
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         state = viewModel.uiState.value
         assertThat(state.data?.contentKey).isEqualTo("two")
+        println("🏁 [TEST DONE] multiple load calls update key")
     }
 
     @Test
     fun `errors cleared after successful load`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] errors cleared after successful load")
         val viewModel = GeneralSettingsViewModel()
         viewModel.onEvent(GeneralSettingsEvent.Load(""))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -77,10 +86,12 @@ class TestGeneralSettingsViewModel {
         state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.errors).isEmpty()
+        println("🏁 [TEST DONE] errors cleared after successful load")
     }
 
     @Test
     fun `content persists across config changes`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] content persists across config changes")
         val viewModel = GeneralSettingsViewModel()
         viewModel.onEvent(GeneralSettingsEvent.Load("rotate"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -89,10 +100,12 @@ class TestGeneralSettingsViewModel {
         // simulate orientation change by checking state again
         val stateAfter = viewModel.uiState.value
         assertThat(stateAfter.data?.contentKey).isEqualTo(stateBefore.data?.contentKey)
+        println("🏁 [TEST DONE] content persists across config changes")
     }
 
     @Test
     fun `reload with same key retains state`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] reload with same key retains state")
         val viewModel = GeneralSettingsViewModel()
         viewModel.onEvent(GeneralSettingsEvent.Load("keep"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -102,10 +115,12 @@ class TestGeneralSettingsViewModel {
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val stateAfter = viewModel.uiState.value
         assertThat(stateAfter).isEqualTo(stateBefore)
+        println("🏁 [TEST DONE] reload with same key retains state")
     }
 
     @Test
     fun `load extremely long content key`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load extremely long content key")
         val viewModel = GeneralSettingsViewModel()
         val longKey = "a".repeat(1000)
         viewModel.onEvent(GeneralSettingsEvent.Load(longKey))
@@ -113,10 +128,12 @@ class TestGeneralSettingsViewModel {
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.contentKey).isEqualTo(longKey)
+        println("🏁 [TEST DONE] load extremely long content key")
     }
 
     @Test
     fun `load content key with special characters`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load content key with special characters")
         val viewModel = GeneralSettingsViewModel()
         val key = "!@#$%^&*()_+漢字"
         viewModel.onEvent(GeneralSettingsEvent.Load(key))
@@ -124,15 +141,18 @@ class TestGeneralSettingsViewModel {
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.contentKey).isEqualTo(key)
+        println("🏁 [TEST DONE] load content key with special characters")
     }
 
     @Test
     fun `concurrent load events yield latest state`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] concurrent load events yield latest state")
         val viewModel = GeneralSettingsViewModel()
         viewModel.onEvent(GeneralSettingsEvent.Load("first"))
         viewModel.onEvent(GeneralSettingsEvent.Load("second"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val state = viewModel.uiState.value
         assertThat(state.data?.contentKey).isEqualTo("second")
+        println("🏁 [TEST DONE] concurrent load events yield latest state")
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/TestSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/TestSettingsViewModel.kt
@@ -41,6 +41,7 @@ class TestSettingsViewModel {
 
     @Test
     fun `load settings success`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load settings success")
         val config = SettingsConfig(title = "title", categories = listOf(SettingsCategory(title = "c")))
         setup(config, dispatcherExtension.testDispatcher)
         val context = mockk<Context>(relaxed = true)
@@ -49,10 +50,12 @@ class TestSettingsViewModel {
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.categories?.size).isEqualTo(1)
+        println("🏁 [TEST DONE] load settings success")
     }
 
     @Test
     fun `load settings empty`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load settings empty")
         val config = SettingsConfig(title = "title", categories = emptyList())
         setup(config, dispatcherExtension.testDispatcher)
         val context = mockk<Context>(relaxed = true)
@@ -62,10 +65,12 @@ class TestSettingsViewModel {
         assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
         val error = state.errors.first().message as UiTextHelper.StringResource
         assertThat(error.resourceId).isEqualTo(R.string.error_no_settings_found)
+        println("🏁 [TEST DONE] load settings empty")
     }
 
     @Test
     fun `load settings provider returns null`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load settings provider returns null")
         dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
         provider = mockk()
         every { provider.provideSettingsConfig(any()) } returns SettingsConfig(title = "null test", categories = emptyList())
@@ -77,10 +82,12 @@ class TestSettingsViewModel {
 
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
+        println("🏁 [TEST DONE] load settings provider returns null")
     }
 
     @Test
     fun `sequential loads reflect latest config`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] sequential loads reflect latest config")
         val context = mockk<Context>(relaxed = true)
         dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
         provider = mockk()
@@ -100,10 +107,12 @@ class TestSettingsViewModel {
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
+        println("🏁 [TEST DONE] sequential loads reflect latest config")
     }
 
     @Test
     fun `provider returns partial config`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] provider returns partial config")
         val config = SettingsConfig(title = "", categories = listOf(SettingsCategory()))
         setup(config, dispatcherExtension.testDispatcher)
         val context = mockk<Context>(relaxed = true)
@@ -112,10 +121,12 @@ class TestSettingsViewModel {
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.title).isEmpty()
+        println("🏁 [TEST DONE] provider returns partial config")
     }
 
     @Test
     fun `load settings with duplicated categories`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load settings with duplicated categories")
         val category = SettingsCategory(title = "dup")
         val config = SettingsConfig(title = "t", categories = listOf(category, category))
         setup(config, dispatcherExtension.testDispatcher)
@@ -125,10 +136,12 @@ class TestSettingsViewModel {
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.categories?.size).isEqualTo(2)
+        println("🏁 [TEST DONE] load settings with duplicated categories")
     }
 
     @Test
     fun `load very large settings config`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load very large settings config")
         val prefs = List(10) { index -> SettingsPreference(key = "k$index") }
         val categories = List(50) { index -> SettingsCategory(title = "c$index", preferences = prefs) }
         val config = SettingsConfig(title = "big", categories = categories)
@@ -139,10 +152,12 @@ class TestSettingsViewModel {
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.categories?.size).isEqualTo(50)
+        println("🏁 [TEST DONE] load very large settings config")
     }
 
     @Test
     fun `load settings with malformed preference`() = runTest(dispatcherExtension.testDispatcher) {
+        println("🚀 [TEST] load settings with malformed preference")
         val malformed = SettingsCategory(
             title = "bad",
             preferences = listOf(SettingsPreference(key = null, title = null))
@@ -157,5 +172,6 @@ class TestSettingsViewModel {
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.categories?.first()?.preferences?.size).isEqualTo(1)
+        println("🏁 [TEST DONE] load settings with malformed preference")
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestClipboardHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestClipboardHelper.kt
@@ -18,6 +18,7 @@ import kotlin.test.assertTrue
 class TestClipboardHelper {
     @Test
     fun `copyTextToClipboard sets primary clip and executes callback when appropriate`() {
+        println("🚀 [TEST] copyTextToClipboard sets primary clip and executes callback when appropriate")
         val manager = mockk<ClipboardManager>()
         val context = mockk<Context>()
         every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns manager
@@ -36,20 +37,24 @@ class TestClipboardHelper {
         } else {
             assertFalse(callbackExecuted)
         }
+        println("🏁 [TEST DONE] copyTextToClipboard sets primary clip and executes callback when appropriate")
     }
 
     @Test
     fun `copyTextToClipboard throws when manager missing`() {
+        println("🚀 [TEST] copyTextToClipboard throws when manager missing")
         val context = mockk<Context>()
         every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns null
 
         assertFailsWith<NullPointerException> {
             ClipboardHelper.copyTextToClipboard(context, "l", "t")
         }
+        println("🏁 [TEST DONE] copyTextToClipboard throws when manager missing")
     }
 
     @Test
     fun `copyTextToClipboard handles manager exception`() {
+        println("🚀 [TEST] copyTextToClipboard handles manager exception")
         val manager = mockk<ClipboardManager>()
         val context = mockk<Context>()
         every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns manager
@@ -58,10 +63,12 @@ class TestClipboardHelper {
         assertFailsWith<RuntimeException> {
             ClipboardHelper.copyTextToClipboard(context, "l", "t")
         }
+        println("🏁 [TEST DONE] copyTextToClipboard handles manager exception")
     }
 
     @Test
     fun `copyTextToClipboard propagates IllegalStateException`() {
+        println("🚀 [TEST] copyTextToClipboard propagates IllegalStateException")
         val manager = mockk<ClipboardManager>()
         val context = mockk<Context>()
         every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns manager
@@ -70,10 +77,12 @@ class TestClipboardHelper {
         assertFailsWith<IllegalStateException> {
             ClipboardHelper.copyTextToClipboard(context, "l", "t")
         }
+        println("🏁 [TEST DONE] copyTextToClipboard propagates IllegalStateException")
     }
 
     @Test
     fun `copyTextToClipboard propagates SecurityException`() {
+        println("🚀 [TEST] copyTextToClipboard propagates SecurityException")
         val manager = mockk<ClipboardManager>()
         val context = mockk<Context>()
         every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns manager
@@ -82,10 +91,12 @@ class TestClipboardHelper {
         assertFailsWith<SecurityException> {
             ClipboardHelper.copyTextToClipboard(context, "l", "t")
         }
+        println("🏁 [TEST DONE] copyTextToClipboard propagates SecurityException")
     }
 
     @Test
     fun `copyTextToClipboard skips callback on Android T or newer`() {
+        println("🚀 [TEST] copyTextToClipboard skips callback on Android T or newer")
         val manager = mockk<ClipboardManager>()
         val context = mockk<Context>()
         every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns manager
@@ -99,10 +110,12 @@ class TestClipboardHelper {
         } else {
             assertTrue(executed)
         }
+        println("🏁 [TEST DONE] copyTextToClipboard skips callback on Android T or newer")
     }
 
     @Test
     fun `copyTextToClipboard propagates exception from callback`() {
+        println("🚀 [TEST] copyTextToClipboard propagates exception from callback")
         val manager = mockk<ClipboardManager>()
         val context = mockk<Context>()
         every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns manager
@@ -121,10 +134,12 @@ class TestClipboardHelper {
         }
 
         verify { manager.setPrimaryClip(any()) }
+        println("🏁 [TEST DONE] copyTextToClipboard propagates exception from callback")
     }
 
     @Test
     fun `copyTextToClipboard handles empty label and text`() {
+        println("🚀 [TEST] copyTextToClipboard handles empty label and text")
         val manager = mockk<ClipboardManager>()
         val context = mockk<Context>()
         every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns manager
@@ -136,10 +151,12 @@ class TestClipboardHelper {
         verify { manager.setPrimaryClip(any()) }
         assertEquals("", clipSlot.captured.description.label)
         assertEquals("", clipSlot.captured.getItemAt(0).text)
+        println("🏁 [TEST DONE] copyTextToClipboard handles empty label and text")
     }
 
     @Test
     fun `copyTextToClipboard handles long label and text`() {
+        println("🚀 [TEST] copyTextToClipboard handles long label and text")
         val manager = mockk<ClipboardManager>()
         val context = mockk<Context>()
         every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns manager
@@ -153,6 +170,7 @@ class TestClipboardHelper {
         verify { manager.setPrimaryClip(any()) }
         assertEquals(longLabel, clipSlot.captured.description.label)
         assertEquals(longText, clipSlot.captured.getItemAt(0).text)
+        println("🏁 [TEST DONE] copyTextToClipboard handles long label and text")
     }
 
     private fun setSdkInt(tempValue: Int, block: () -> Unit) {
@@ -174,6 +192,7 @@ class TestClipboardHelper {
 
     @Test
     fun `copyTextToClipboard skips callback exactly on API 33`() {
+        println("🚀 [TEST] copyTextToClipboard skips callback exactly on API 33")
         val manager = mockk<ClipboardManager>()
         val context = mockk<Context>()
         every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns manager
@@ -185,16 +204,19 @@ class TestClipboardHelper {
         }
 
         assertFalse(executed)
+        println("🏁 [TEST DONE] copyTextToClipboard skips callback exactly on API 33")
     }
 
     @Test
     fun `copyTextToClipboard throws when clipboard service type unexpected`() {
+        println("🚀 [TEST] copyTextToClipboard throws when clipboard service type unexpected")
         val context = mockk<Context>()
         every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns "not a manager"
 
         assertFailsWith<ClassCastException> {
             ClipboardHelper.copyTextToClipboard(context, "l", "t")
         }
+        println("🏁 [TEST DONE] copyTextToClipboard throws when clipboard service type unexpected")
     }
 }
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestConsentManagerHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestConsentManagerHelper.kt
@@ -28,6 +28,7 @@ class TestConsentManagerHelper {
 
     @Test
     fun `updateConsent passes values to firebase`() {
+        println("🚀 [TEST] updateConsent passes values to firebase")
         val analytics = mockk<FirebaseAnalytics>(relaxed = true)
         mockkObject(Firebase)
         every { Firebase.analytics } returns analytics
@@ -48,11 +49,13 @@ class TestConsentManagerHelper {
                 it[FirebaseAnalytics.ConsentType.AD_PERSONALIZATION] == FirebaseAnalytics.ConsentStatus.DENIED
             })
         }
+        println("🏁 [TEST DONE] updateConsent passes values to firebase")
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `applyInitialConsent reads datastore and initializes firebase`() = runTest {
+        println("🚀 [TEST] applyInitialConsent reads datastore and initializes firebase")
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.analyticsConsent(any()) } returns flowOf(true)
         every { dataStore.adStorageConsent(any()) } returns flowOf(false)
@@ -83,11 +86,13 @@ class TestConsentManagerHelper {
         verify { performance.isPerformanceCollectionEnabled = true }
 
         stopKoin()
+        println("🏁 [TEST DONE] applyInitialConsent reads datastore and initializes firebase")
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `updateAnalyticsCollectionFromDatastore sets collection flags`() = runTest {
+        println("🚀 [TEST] updateAnalyticsCollectionFromDatastore sets collection flags")
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.usageAndDiagnostics(any()) } returnsMany listOf(flowOf(true), flowOf(false))
 
@@ -110,10 +115,12 @@ class TestConsentManagerHelper {
         verify { analytics.setAnalyticsCollectionEnabled(false) }
         verify { crashlytics.isCrashlyticsCollectionEnabled = false }
         verify { performance.isPerformanceCollectionEnabled = false }
+        println("🏁 [TEST DONE] updateAnalyticsCollectionFromDatastore sets collection flags")
     }
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `applyInitialConsent propagates io exception`() = runTest {
+        println("🚀 [TEST] applyInitialConsent propagates io exception")
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.analyticsConsent(any()) } returns flow { throw java.io.IOException("io") }
         every { dataStore.adStorageConsent(any()) } returns flowOf(true)
@@ -133,11 +140,13 @@ class TestConsentManagerHelper {
         }
 
         stopKoin()
+        println("🏁 [TEST DONE] applyInitialConsent propagates io exception")
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `applyInitialConsent propagates cancellation exception`() = runTest {
+        println("🚀 [TEST] applyInitialConsent propagates cancellation exception")
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.analyticsConsent(any()) } returns flow { throw kotlinx.coroutines.CancellationException("cancel") }
         every { dataStore.adStorageConsent(any()) } returns flowOf(true)
@@ -157,11 +166,13 @@ class TestConsentManagerHelper {
         }
 
         stopKoin()
+        println("🏁 [TEST DONE] applyInitialConsent propagates cancellation exception")
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `updateAnalyticsCollectionFromDatastore propagates firebase failure`() = runTest {
+        println("🚀 [TEST] updateAnalyticsCollectionFromDatastore propagates firebase failure")
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.usageAndDiagnostics(any()) } returns flowOf(true)
 
@@ -179,11 +190,13 @@ class TestConsentManagerHelper {
         assertFailsWith<RuntimeException> {
             ConsentManagerHelper.updateAnalyticsCollectionFromDatastore(dataStore)
         }
+        println("🏁 [TEST DONE] updateAnalyticsCollectionFromDatastore propagates firebase failure")
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `applyInitialConsent when debug build uses datastore values`() = runTest {
+        println("🚀 [TEST] applyInitialConsent when debug build uses datastore values")
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.analyticsConsent(any()) } returns flowOf(false)
         every { dataStore.adStorageConsent(any()) } returns flowOf(false)
@@ -217,10 +230,12 @@ class TestConsentManagerHelper {
         verify { performance.isPerformanceCollectionEnabled = false }
 
         stopKoin()
+        println("🏁 [TEST DONE] applyInitialConsent when debug build uses datastore values")
     }
 
     @Test
     fun `updateConsent propagates firebase exception`() {
+        println("🚀 [TEST] updateConsent propagates firebase exception")
         val analytics = mockk<FirebaseAnalytics>()
         mockkObject(Firebase)
         every { Firebase.analytics } returns analytics
@@ -229,11 +244,13 @@ class TestConsentManagerHelper {
         assertFailsWith<RuntimeException> {
             ConsentManagerHelper.updateConsent(true, true, true, true)
         }
+        println("🏁 [TEST DONE] updateConsent propagates firebase exception")
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `updateAnalyticsCollectionFromDatastore toggles false to true`() = runTest {
+        println("🚀 [TEST] updateAnalyticsCollectionFromDatastore toggles false to true")
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.usageAndDiagnostics(any()) } returnsMany listOf(flowOf(false), flowOf(true))
 
@@ -256,10 +273,12 @@ class TestConsentManagerHelper {
         verify { analytics.setAnalyticsCollectionEnabled(true) }
         verify { crashlytics.isCrashlyticsCollectionEnabled = true }
         verify { performance.isPerformanceCollectionEnabled = true }
+        println("🏁 [TEST DONE] updateAnalyticsCollectionFromDatastore toggles false to true")
     }
 
     @Test
     fun `defaultAnalyticsGranted false when debug build`() {
+        println("🚀 [TEST] defaultAnalyticsGranted false when debug build")
         val provider = mockk<BuildInfoProvider>()
         every { provider.isDebugBuild } returns true
         startKoin { modules(module { single<BuildInfoProvider> { provider } }) }
@@ -271,5 +290,6 @@ class TestConsentManagerHelper {
         assertFalse(ConsentManagerHelper.defaultAnalyticsGranted)
 
         stopKoin()
+        println("🏁 [TEST DONE] defaultAnalyticsGranted false when debug build")
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestIntentsHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestIntentsHelper.kt
@@ -24,6 +24,7 @@ class TestIntentsHelper {
 
     @Test
     fun `openUrl starts ACTION_VIEW intent`() {
+        println("🚀 [TEST] openUrl starts ACTION_VIEW intent")
         val context = mockk<Context>()
         val intentSlot = slot<Intent>()
         justRun { context.startActivity(capture(intentSlot)) }
@@ -34,10 +35,12 @@ class TestIntentsHelper {
         assertEquals(Intent.ACTION_VIEW, intent.action)
         assertEquals("https://example.com", intent.data.toString())
         assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+        println("🏁 [TEST DONE] openUrl starts ACTION_VIEW intent")
     }
 
     @Test
     fun `openActivity starts activity with new task flag`() {
+        println("🚀 [TEST] openActivity starts activity with new task flag")
         val context = mockk<Context>()
         val intentSlot = slot<Intent>()
         justRun { context.startActivity(capture(intentSlot)) }
@@ -47,30 +50,36 @@ class TestIntentsHelper {
         val intent = intentSlot.captured
         assertEquals(String::class.java.name, intent.component?.className)
         assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+        println("🏁 [TEST DONE] openActivity starts activity with new task flag")
     }
 
     @Test
     fun `openUrl propagates exception`() {
+        println("🚀 [TEST] openUrl propagates exception")
         val context = mockk<Context>()
         every { context.startActivity(any()) } throws RuntimeException("fail")
 
         assertFailsWith<RuntimeException> {
             IntentsHelper.openUrl(context, "https://example.com")
         }
+        println("🏁 [TEST DONE] openUrl propagates exception")
     }
 
     @Test
     fun `openActivity propagates exception`() {
+        println("🚀 [TEST] openActivity propagates exception")
         val context = mockk<Context>()
         every { context.startActivity(any()) } throws RuntimeException("fail")
 
         assertFailsWith<RuntimeException> {
             IntentsHelper.openActivity(context, String::class.java)
         }
+        println("🏁 [TEST DONE] openActivity propagates exception")
     }
 
     @Test
     fun `openAppNotificationSettings builds correct intent`() {
+        println("🚀 [TEST] openAppNotificationSettings builds correct intent")
         val context = mockk<Context>()
         every { context.packageName } returns "pkg"
         val slot = slot<Intent>()
@@ -87,10 +96,12 @@ class TestIntentsHelper {
             assertEquals("android.settings.APPLICATION_DETAILS_SETTINGS", intent.action)
             assertEquals(Uri.fromParts("package", "pkg", null), intent.data)
         }
+        println("🏁 [TEST DONE] openAppNotificationSettings builds correct intent")
     }
 
     @Test
     fun `openPlayStoreForApp uses market when resolvable`() {
+        println("🚀 [TEST] openPlayStoreForApp uses market when resolvable")
         val context = mockk<Context>()
         val pm = mockk<PackageManager>()
         every { context.packageManager } returns pm
@@ -106,10 +117,12 @@ class TestIntentsHelper {
         assertEquals(Intent.ACTION_VIEW, intent.action)
         assertEquals("${AppLinks.MARKET_APP_PAGE}com.test", intent.data.toString())
         assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+        println("🏁 [TEST DONE] openPlayStoreForApp uses market when resolvable")
     }
 
     @Test
     fun `openPlayStoreForApp falls back to web when market missing`() {
+        println("🚀 [TEST] openPlayStoreForApp falls back to web when market missing")
         val context = mockk<Context>()
         val pm = mockk<PackageManager>()
         every { context.packageManager } returns pm
@@ -124,10 +137,12 @@ class TestIntentsHelper {
         val intent = slot.captured
         assertEquals(Intent.ACTION_VIEW, intent.action)
         assertEquals("${AppLinks.PLAY_STORE_APP}com.test", intent.data.toString())
+        println("🏁 [TEST DONE] openPlayStoreForApp falls back to web when market missing")
     }
 
     @Test
     fun `shareApp builds chooser intent`() {
+        println("🚀 [TEST] shareApp builds chooser intent")
         val context = mockk<Context>()
         val res = mockk<Resources>()
         every { context.resources } returns res
@@ -149,10 +164,12 @@ class TestIntentsHelper {
         assertEquals(Intent.ACTION_SEND, sendIntent?.action)
         assertEquals("msg", sendIntent?.getStringExtra(Intent.EXTRA_TEXT))
         assertEquals("text/plain", sendIntent?.type)
+        println("🏁 [TEST DONE] shareApp builds chooser intent")
     }
 
     @Test
     fun `sendEmailToDeveloper builds mailto chooser`() {
+        println("🚀 [TEST] sendEmailToDeveloper builds mailto chooser")
         val context = mockk<Context>()
         every { context.getString(R.string.feedback_for, "App") } returns "subject"
         every { context.getString(R.string.dear_developer) } returns "body"
@@ -172,10 +189,12 @@ class TestIntentsHelper {
         }
         assertEquals(Intent.ACTION_SENDTO, inner?.action)
         assertTrue(inner?.data.toString().startsWith("mailto:"))
+        println("🏁 [TEST DONE] sendEmailToDeveloper builds mailto chooser")
     }
 
     @Test
     fun `openAppNotificationSettings propagates exception`() {
+        println("🚀 [TEST] openAppNotificationSettings propagates exception")
         val context = mockk<Context>()
         every { context.packageName } returns "pkg"
         every { context.startActivity(any()) } throws RuntimeException("fail")
@@ -183,10 +202,12 @@ class TestIntentsHelper {
         assertFailsWith<RuntimeException> {
             IntentsHelper.openAppNotificationSettings(context)
         }
+        println("🏁 [TEST DONE] openAppNotificationSettings propagates exception")
     }
 
     @Test
     fun `openPlayStoreForApp propagates exception`() {
+        println("🚀 [TEST] openPlayStoreForApp propagates exception")
         val context = mockk<Context>()
         val pm = mockk<PackageManager>()
         every { context.packageManager } returns pm
@@ -197,10 +218,12 @@ class TestIntentsHelper {
         assertFailsWith<RuntimeException> {
             IntentsHelper.openPlayStoreForApp(context, "com.test")
         }
+        println("🏁 [TEST DONE] openPlayStoreForApp propagates exception")
     }
 
     @Test
     fun `shareApp propagates exception`() {
+        println("🚀 [TEST] shareApp propagates exception")
         val context = mockk<Context>()
         val res = mockk<Resources>()
         every { context.resources } returns res
@@ -211,10 +234,12 @@ class TestIntentsHelper {
         assertFailsWith<RuntimeException> {
             IntentsHelper.shareApp(context, R.string.summary_share_message)
         }
+        println("🏁 [TEST DONE] shareApp propagates exception")
     }
 
     @Test
     fun `sendEmailToDeveloper propagates exception`() {
+        println("🚀 [TEST] sendEmailToDeveloper propagates exception")
         val context = mockk<Context>()
         every { context.getString(R.string.feedback_for, "App") } returns "subject"
         every { context.getString(R.string.dear_developer) } returns "body"
@@ -224,10 +249,12 @@ class TestIntentsHelper {
         assertFailsWith<RuntimeException> {
             IntentsHelper.sendEmailToDeveloper(context, R.string.app_name)
         }
+        println("🏁 [TEST DONE] sendEmailToDeveloper propagates exception")
     }
 
     @Test
     fun `openPlayStoreForApp with empty package name`() {
+        println("🚀 [TEST] openPlayStoreForApp with empty package name")
         val context = mockk<Context>()
         val pm = mockk<PackageManager>()
         every { context.packageManager } returns pm
@@ -242,10 +269,12 @@ class TestIntentsHelper {
         val intent = slot.captured
         assertEquals(Intent.ACTION_VIEW, intent.action)
         assertEquals(AppLinks.MARKET_APP_PAGE, intent.data.toString())
+        println("🏁 [TEST DONE] openPlayStoreForApp with empty package name")
     }
 
     @Test
     fun `openPlayStoreForApp null package throws`() {
+        println("🚀 [TEST] openPlayStoreForApp null package throws")
         val context = mockk<Context>()
         val method = IntentsHelper::class.java.getDeclaredMethod(
             "openPlayStoreForApp",
@@ -256,10 +285,12 @@ class TestIntentsHelper {
         assertFailsWith<NullPointerException> {
             method.invoke(IntentsHelper, context, null)
         }
+        println("🏁 [TEST DONE] openPlayStoreForApp null package throws")
     }
 
     @Test
     fun `openUrl handles malformed url`() {
+        println("🚀 [TEST] openUrl handles malformed url")
         val context = mockk<Context>()
         val slot = slot<Intent>()
         justRun { context.startActivity(capture(slot)) }
@@ -269,10 +300,12 @@ class TestIntentsHelper {
         val intent = slot.captured
         assertEquals(Intent.ACTION_VIEW, intent.action)
         assertEquals("htp::://bad url", intent.data.toString())
+        println("🏁 [TEST DONE] openUrl handles malformed url")
     }
 
     @Test
     fun `openPlayStoreForApp handles unusual package name`() {
+        println("🚀 [TEST] openPlayStoreForApp handles unusual package name")
         val context = mockk<Context>()
         val pm = mockk<PackageManager>()
         every { context.packageManager } returns pm
@@ -287,10 +320,12 @@ class TestIntentsHelper {
 
         val intent = slot.captured
         assertEquals("${AppLinks.MARKET_APP_PAGE}$pkg", intent.data.toString())
+        println("🏁 [TEST DONE] openPlayStoreForApp handles unusual package name")
     }
 
     @Test
     fun `shareApp uses provided chooser title`() {
+        println("🚀 [TEST] shareApp uses provided chooser title")
         val context = mockk<Context>()
         val res = mockk<Resources>()
         every { context.resources } returns res
@@ -303,10 +338,12 @@ class TestIntentsHelper {
 
         val chooser = slot.captured
         assertEquals("Share via \u2728", chooser.getCharSequenceExtra(Intent.EXTRA_TITLE))
+        println("🏁 [TEST DONE] shareApp uses provided chooser title")
     }
 
     @Test
     fun `sendEmailToDeveloper uses provided chooser title`() {
+        println("🚀 [TEST] sendEmailToDeveloper uses provided chooser title")
         val context = mockk<Context>()
         every { context.getString(R.string.feedback_for, "App") } returns "subject"
         every { context.getString(R.string.dear_developer) } returns "body"
@@ -318,10 +355,12 @@ class TestIntentsHelper {
 
         val chooser = slot.captured
         assertEquals("Email via \uD83D\uDE80", chooser.getCharSequenceExtra(Intent.EXTRA_TITLE))
+        println("🏁 [TEST DONE] sendEmailToDeveloper uses provided chooser title")
     }
 
     @Test
     fun `openAppNotificationSettings uses legacy intent pre O`() {
+        println("🚀 [TEST] openAppNotificationSettings uses legacy intent pre O")
         val context = mockk<Context>()
         every { context.packageName } returns "pkg"
         val slot = slot<Intent>()
@@ -335,5 +374,6 @@ class TestIntentsHelper {
         val intent = slot.captured
         assertEquals("android.settings.APPLICATION_DETAILS_SETTINGS", intent.action)
         assertEquals(Uri.fromParts("package", "pkg", null), intent.data)
+        println("🏁 [TEST DONE] openAppNotificationSettings uses legacy intent pre O")
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestPermissionsHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestPermissionsHelper.kt
@@ -22,6 +22,7 @@ class TestPermissionsHelper {
 
     @Test
     fun `hasNotificationPermission parses permission state`() {
+        println("🚀 [TEST] hasNotificationPermission parses permission state")
         val context = mockk<Context>()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             mockkStatic(ContextCompat::class)
@@ -32,10 +33,12 @@ class TestPermissionsHelper {
         } else {
             assertTrue(PermissionsHelper.hasNotificationPermission(context))
         }
+        println("🏁 [TEST DONE] hasNotificationPermission parses permission state")
     }
 
     @Test
     fun `requestNotificationPermission delegates to ActivityCompat when needed`() {
+        println("🚀 [TEST] requestNotificationPermission delegates to ActivityCompat when needed")
         val activity = mockk<Activity>()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             mockkStatic(ActivityCompat::class)
@@ -47,10 +50,12 @@ class TestPermissionsHelper {
             PermissionsHelper.requestNotificationPermission(activity)
             verify(exactly = 0) { ActivityCompat.requestPermissions(any(), any(), any()) }
         }
+        println("🏁 [TEST DONE] requestNotificationPermission delegates to ActivityCompat when needed")
     }
 
     @Test
     fun `hasNotificationPermission handles unexpected value`() {
+        println("🚀 [TEST] hasNotificationPermission handles unexpected value")
         val context = mockk<Context>()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             mockkStatic(ContextCompat::class)
@@ -59,10 +64,12 @@ class TestPermissionsHelper {
         } else {
             assertTrue(PermissionsHelper.hasNotificationPermission(context))
         }
+        println("🏁 [TEST DONE] hasNotificationPermission handles unexpected value")
     }
 
     @Test
     fun `hasNotificationPermission propagates exception`() {
+        println("🚀 [TEST] hasNotificationPermission propagates exception")
         val context = mockk<Context>()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             mockkStatic(ContextCompat::class)
@@ -71,10 +78,12 @@ class TestPermissionsHelper {
         } else {
             assertTrue(PermissionsHelper.hasNotificationPermission(context))
         }
+        println("🏁 [TEST DONE] hasNotificationPermission propagates exception")
     }
 
     @Test
     fun `requestNotificationPermission propagates exception`() {
+        println("🚀 [TEST] requestNotificationPermission propagates exception")
         val activity = mockk<Activity>()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             mockkStatic(ActivityCompat::class)
@@ -85,10 +94,12 @@ class TestPermissionsHelper {
             PermissionsHelper.requestNotificationPermission(activity)
             verify(exactly = 0) { ActivityCompat.requestPermissions(any(), any(), any()) }
         }
+        println("🏁 [TEST DONE] requestNotificationPermission propagates exception")
     }
 
     @Test
     fun `hasNotificationPermission handles other unknown values`() {
+        println("🚀 [TEST] hasNotificationPermission handles other unknown values")
         val context = mockk<Context>()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             mockkStatic(ContextCompat::class)
@@ -98,10 +109,12 @@ class TestPermissionsHelper {
         } else {
             assertTrue(PermissionsHelper.hasNotificationPermission(context))
         }
+        println("🏁 [TEST DONE] hasNotificationPermission handles other unknown values")
     }
 
     @Test
     fun `hasNotificationPermission reflects runtime revocation`() {
+        println("🚀 [TEST] hasNotificationPermission reflects runtime revocation")
         val context = mockk<Context>()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             mockkStatic(ContextCompat::class)
@@ -115,5 +128,6 @@ class TestPermissionsHelper {
             assertTrue(PermissionsHelper.hasNotificationPermission(context))
             assertTrue(PermissionsHelper.hasNotificationPermission(context))
         }
+        println("🏁 [TEST DONE] hasNotificationPermission reflects runtime revocation")
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/data/core/ads/TestAdsCoreManager.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/data/core/ads/TestAdsCoreManager.kt
@@ -24,6 +24,7 @@ import java.util.Date
 class TestAdsCoreManager {
     @Test
     fun `initializeAds triggers MobileAds`() {
+        println("🚀 [TEST] initializeAds triggers MobileAds")
         val context = mockk<Context>()
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
@@ -33,20 +34,24 @@ class TestAdsCoreManager {
 
         manager.initializeAds("id")
         verify { MobileAds.initialize(context) }
+        println("🏁 [TEST DONE] initializeAds triggers MobileAds")
     }
 
     @Test
     fun `showAdIfAvailable before init does nothing`() {
+        println("🚀 [TEST] showAdIfAvailable before init does nothing")
         val context = mockk<Context>()
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
         val activity = mockk<Activity>()
 
         manager.showAdIfAvailable(activity)
+        println("🏁 [TEST DONE] showAdIfAvailable before init does nothing")
     }
 
     @Test
     fun `loadAd does not load when already loading or available`() {
+        println("🚀 [TEST] loadAd does not load when already loading or available")
         val context = mockk<Context>()
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
@@ -80,10 +85,12 @@ class TestAdsCoreManager {
             invoke(inner, context)
         }
         verify(exactly = 0) { AppOpenAd.load(any(), any(), any(), any()) }
+        println("🏁 [TEST DONE] loadAd does not load when already loading or available")
     }
 
     @Test
     fun `showAdIfAvailable loads when no ad`() {
+        println("🚀 [TEST] showAdIfAvailable loads when no ad")
         val context = mockk<Context>()
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
@@ -113,10 +120,12 @@ class TestAdsCoreManager {
 
         assert(completed)
         verify { AppOpenAd.load(any(), any(), any(), any()) }
+        println("🏁 [TEST DONE] showAdIfAvailable loads when no ad")
     }
 
     @Test
     fun `callback dismiss reloads ad`() {
+        println("🚀 [TEST] callback dismiss reloads ad")
         val context = mockk<Context>(relaxed = true)
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
@@ -158,10 +167,12 @@ class TestAdsCoreManager {
         showField.isAccessible = true
         assertFalse(showField.getBoolean(inner3))
         verify { AppOpenAd.load(any(), any(), any(), any()) }
+        println("🏁 [TEST DONE] callback dismiss reloads ad")
     }
 
     @Test
     fun `ads disabled skips load and show`() {
+        println("🚀 [TEST] ads disabled skips load and show")
         val context = mockk<Context>()
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
@@ -180,10 +191,12 @@ class TestAdsCoreManager {
         manager.showAdIfAvailable(activity)
 
         verify(exactly = 0) { AppOpenAd.load(any(), any(), any(), any()) }
+        println("🏁 [TEST DONE] ads disabled skips load and show")
     }
 
     @Test
     fun `load failure resets loading flag`() {
+        println("🚀 [TEST] load failure resets loading flag")
         val context = mockk<Context>()
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
@@ -215,10 +228,12 @@ class TestAdsCoreManager {
         val loadingField = inner.javaClass.getDeclaredField("isLoadingAd")
         loadingField.isAccessible = true
         assertFalse(loadingField.getBoolean(inner))
+        println("🏁 [TEST DONE] load failure resets loading flag")
     }
 
     @Test
     fun `showAdIfAvailable ignores when already showing`() {
+        println("🚀 [TEST] showAdIfAvailable ignores when already showing")
         val context = mockk<Context>()
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
@@ -249,10 +264,12 @@ class TestAdsCoreManager {
         method.invoke(inner, mockk<Activity>(), mockk<OnShowAdCompleteListener>())
 
         verify(exactly = 0) { AppOpenAd.load(any(), any(), any(), any()) }
+        println("🏁 [TEST DONE] showAdIfAvailable ignores when already showing")
     }
 
     @Test
     fun `concurrent load requests chain correctly`() {
+        println("🚀 [TEST] concurrent load requests chain correctly")
         val context = mockk<Context>()
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
@@ -291,10 +308,12 @@ class TestAdsCoreManager {
         }
 
         verify(exactly = 2) { AppOpenAd.load(any(), any(), any(), any()) }
+        println("🏁 [TEST DONE] concurrent load requests chain correctly")
     }
 
     @Test
     fun `loadAd propagates exceptions from AppOpenAd`() {
+        println("🚀 [TEST] loadAd propagates exceptions from AppOpenAd")
         val context = mockk<Context>()
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
@@ -321,10 +340,12 @@ class TestAdsCoreManager {
         val loadingField = inner.javaClass.getDeclaredField("isLoadingAd")
         loadingField.isAccessible = true
         assert(loadingField.getBoolean(inner))
+        println("🏁 [TEST DONE] loadAd propagates exceptions from AppOpenAd")
     }
 
     @Test
     fun `ads disabled by default when debug build`() {
+        println("🚀 [TEST] ads disabled by default when debug build")
         val context = mockk<Context>()
         val provider = mockk<BuildInfoProvider>()
         every { provider.isDebugBuild } returns true
@@ -345,10 +366,12 @@ class TestAdsCoreManager {
 
         assert(!slot.captured)
         verify(exactly = 0) { AppOpenAd.load(any(), any(), any(), any()) }
+        println("🏁 [TEST DONE] ads disabled by default when debug build")
     }
 
     @Test
     fun `ads enabled by default when release build`() {
+        println("🚀 [TEST] ads enabled by default when release build")
         val context = mockk<Context>()
         val provider = mockk<BuildInfoProvider>()
         every { provider.isDebugBuild } returns false
@@ -369,6 +392,7 @@ class TestAdsCoreManager {
 
         assert(slot.captured)
         verify { AppOpenAd.load(any(), any(), any(), any()) }
+        println("🏁 [TEST DONE] ads enabled by default when release build")
     }
 
 }


### PR DESCRIPTION
## Summary
- add `println` logs to remaining unit tests following existing emoji style
- restore `TestSettingsViewModel` with logging

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3015ee28832d88d31509cf43e95a